### PR TITLE
BUG: fix bug with missing.action == "remove"

### DIFF
--- a/MSstats.daily/R/mainfunctions.R
+++ b/MSstats.daily/R/mainfunctions.R
@@ -2605,7 +2605,10 @@ if ( missing.action == "impute" ) {
 
 ## 
 if ( missing.action == "remove" ){
-	data<-data[-which(data$FEATURE %in% missingPeptides),]
+	# if no peptides are missing, -which doesn't work right
+	if (length(missingPeptides) > 0) {
+		data<-data[-which(data$FEATURE %in% missingPeptides),]
+	}
 
 	message("* The features that are missing intensities for an entire condition in Protein will be removed for fitting the model.")
 	


### PR DESCRIPTION
If the data doesn't have any missing peptides (e.g. it has been preprocessed to remove them), the current code crashes because -which selects everything and there are no proteins left. This just adds a check for no missing peptides
