### PR TITLE
fix DESCRIPTION to have biocViews instead of bioViews

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports: Rcpp, lme4, marray, limma, gplots, ggplot2, methods, grid, ggrepel, pre
   data.table, MSnbase, reshape, reshape2, survival, minpack.lm, utils
 Suggests: knitr, rmarkdown
 VignetteBuilder: knitr
-bioViews: Bioinformatics, MassSpectrometry, Proteomics, Software
+biocViews: Bioinformatics, MassSpectrometry, Proteomics, Software
 LazyData: true
 URL: http://msstats.org
 BugReports: https://groups.google.com/forum/#!forum/msstats


### PR DESCRIPTION
I had trouble deploying an app to shinyapps.io, and it looks like it was because the DESCRIPTION file specified `bioViews` instead of `biocViews`.