### PR TITLE
[FIX] Corner case during stage 3 filtering of features

### DIFF
--- a/R/DataProcess.R
+++ b/R/DataProcess.R
@@ -539,10 +539,12 @@ dataProcess  <-  function(raw,
 	                                     function(x) max(x))
 	                max.feature.1 <- count.feature3[max.feature == 1, 'FEATURE'] 
 	                
-	                work <- work[-which(work$FEATURE %in% max.feature.1), ]
+			if (length(max.feature.1) > 0)
+          		{
+	                    work <- work[-which(work$FEATURE %in% max.feature.1), ]
 	                
-	                count.feature3 <- count.feature3[-which(count.feature3$FEATURE %in% max.feature.1), ]
-	                
+	                    count.feature3 <- count.feature3[-which(count.feature3$FEATURE %in% max.feature.1), ]
+	                }
 	                if ( nrow(count.feature3) > 0 ) {
 	                    
 	                    ###############


### PR DESCRIPTION
Hi @MeenaChoi ,

This potentially fixes an error when the actual vector of FEATURES in max.feature.1 is empty.
This results in work[-0,] which basically filters the full dataset.

Let me know if this is correct. At least it fixes an error for us.

Otherwise, feel free to close and I will open an issue with the exact problem we encounter.
Best, Julianus