### PR TITLE
Safeguard against failing "augment" of failed robust lm fits in outlier detection

### DIFF
--- a/R/select-msfeature-msstats.R
+++ b/R/select-msfeature-msstats.R
@@ -259,7 +259,7 @@ flag_noninf_data <- function(processedData) {
         list_var <- vector("list", nrow(nested_prot))
         for (i in seq_along(list_var)) {
             s_eb <- nested_prot$s_resid_eb[i]
-            if (!is.na(s_eb)) {
+            if (!is.na(s_eb) & !all(is.na(nested_prot$rlm_fit[[i]]$residuals))) {
                 augdata <- nested_prot$rlm_fit[[i]] %>% augment()
                 if (lab == "L") {
                     list_var[[i]] <- calc_fvar(augdata, s_eb, rm_olr = TRUE)


### PR DESCRIPTION
Hi @MeenaChoi 

while testing some datasets with the highQuality/outlierRemoval mode, we encountered some issues
with the "augment" function which does not seem to work when the underlying rlm fails or somehow behaves strangely. The current check was somehow not enough.
While I think this should be solved in the "augment" package, maybe we can add this safeguard until this gets solved.
Otherwise, the script fails. With this PR I just ignore those failed fits.

Have a look if this additional check makes sense. Feel free to adapt the PR to circumvent this problem in another way if you have an idea.