### PR TITLE
docs(news): Add news on parallel processing capabilities for release 3.19

### DIFF
--- a/inst/NEWS.rd
+++ b/inst/NEWS.rd
@@ -2,6 +2,13 @@
 \title{News for package, \pkg{MSstats}}
 \encoding{UTF-8}
 
+\section{Version 4.12.0 (2024-05-01)}{
+    \itemize{
+        \item groupComparison : Added numberOfCores parameter to enable parallel processing
+        \item dataProcess : Added numberOfCores parameter to enable parallel processing
+    }
+}
+
 \section{Version 4.10.0 (2023-10-23)}{
     \itemize{
         \item Added functions to convert SDRF annotation files into MSstats annotation format.


### PR DESCRIPTION
# Motivation and Context

[Release 3.19](https://www.bioconductor.org/developers/release-schedule/) is coming up.  We should add new parallel processing capabilities as part of the news of MSstats.

## Changes

- Update news.md with parallel processing changes.

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules