### PR TITLE
docs(remove50Missing): Clarify documentation regarding remove50Missing parameter

### DIFF
--- a/R/dataProcess.R
+++ b/R/dataProcess.R
@@ -45,8 +45,8 @@
 #' @param MBimpute only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
 #' TRUE (default) imputes 'NA' or '0' (depending on censoredInt option) 
 #' by Accelated failure model. FALSE uses the values assigned by cutoffCensored.
-#' @param remove50missing only for summaryMethod = "TMP". TRUE removes the runs 
-#' which have more than 50\% missing values. FALSE is default.
+#' @param remove50missing only for summaryMethod = "TMP". TRUE removes the proteins 
+#' where every run has at least 50\% missing values for each peptide. FALSE is default.
 #' @param maxQuantileforCensored Maximum quantile for deciding censored missing values, default is 0.999
 #' @param fix_missing Optional, same as the `fix_missing` parameter in MSstatsConvert::MSstatsBalancedDesign function
 #' @param numberOfCores Number of cores for parallel processing. When > 1, 
@@ -145,8 +145,8 @@ dataProcess = function(
 #' In this case, NA intensities are missing at random. 
 #' The output from Skyline should use '0'. 
 #' Null assumes that all NA intensites are randomly missing.
-#' @param remove50missing only for summaryMethod = "TMP". TRUE removes the runs 
-#' which have more than 50\% missing values. FALSE is default.
+#' @param remove50missing only for summaryMethod = "TMP". TRUE removes the proteins 
+#' where every run has at least 50\% missing values for each peptide. FALSE is default.
 #' @param impute only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
 #' TRUE (default) imputes 'NA' or '0' (depending on censoredInt option) by Accelated failure model. 
 #' FALSE uses the values assigned by cutoffCensored
@@ -206,24 +206,7 @@ MSstatsSummarizeWithMultipleCores = function(input, method, impute, censored_sym
 #' Feature-level data summarization
 #' 
 #' @param proteins_list list of processed feature-level data
-#' @param method summarization method: "linear" or "TMP" 
-#' @param equal_variance only for summaryMethod = "linear". Default is TRUE. 
-#' Logical variable for whether the model should account for heterogeneous variation 
-#' among intensities from different features. Default is TRUE, which assume equal
-#' variance among intensities from features. FALSE means that we cannot assume 
-#' equal variance among intensities from features, then we will account for
-#' heterogeneous variation from different features.
-#' @param censored_symbol Missing values are censored or at random. 
-#' 'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-#' '0' uses zero intensities as censored intensity. 
-#' In this case, NA intensities are missing at random. 
-#' The output from Skyline should use '0'. 
-#' Null assumes that all NA intensites are randomly missing.
-#' @param remove50missing only for summaryMethod = "TMP". TRUE removes the runs 
-#' which have more than 50\% missing values. FALSE is default.
-#' @param impute only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
-#' TRUE (default) imputes 'NA' or '0' (depending on censoredInt option) by Accelated failure model. 
-#' FALSE uses the values assigned by cutoffCensored
+#' @inheritParams MSstatsSummarizeWithMultipleCores
 #' 
 #' @importFrom data.table uniqueN
 #' @importFrom utils setTxtProgressBar

--- a/man/MSstatsSummarize.Rd
+++ b/man/MSstatsSummarize.Rd
@@ -29,8 +29,8 @@ In this case, NA intensities are missing at random.
 The output from Skyline should use '0'. 
 Null assumes that all NA intensites are randomly missing.}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the runs 
-which have more than 50\% missing values. FALSE is default.}
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+where every run has at least 50\% missing values for each peptide. FALSE is default.}
 
 \item{equal_variance}{only for summaryMethod = "linear". Default is TRUE. 
 Logical variable for whether the model should account for heterogeneous variation 

--- a/man/MSstatsSummarizeSingleTMP.Rd
+++ b/man/MSstatsSummarizeSingleTMP.Rd
@@ -25,8 +25,8 @@ In this case, NA intensities are missing at random.
 The output from Skyline should use '0'. 
 Null assumes that all NA intensites are randomly missing.}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the runs 
-which have more than 50\% missing values. FALSE is default.}
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+where every run has at least 50\% missing values for each peptide. FALSE is default.}
 }
 \value{
 list of two data.tables: one with fitted survival model,

--- a/man/MSstatsSummarizeWithMultipleCores.Rd
+++ b/man/MSstatsSummarizeWithMultipleCores.Rd
@@ -30,8 +30,8 @@ In this case, NA intensities are missing at random.
 The output from Skyline should use '0'. 
 Null assumes that all NA intensites are randomly missing.}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the runs 
-which have more than 50\% missing values. FALSE is default.}
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+where every run has at least 50\% missing values for each peptide. FALSE is default.}
 
 \item{equal_variance}{only for summaryMethod = "linear". Default is TRUE. 
 Logical variable for whether the model should account for heterogeneous variation 

--- a/man/dataProcess.Rd
+++ b/man/dataProcess.Rd
@@ -85,8 +85,8 @@ Null assumes that all NA intensites are randomly missing.}
 TRUE (default) imputes 'NA' or '0' (depending on censoredInt option) 
 by Accelated failure model. FALSE uses the values assigned by cutoffCensored.}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the runs 
-which have more than 50\% missing values. FALSE is default.}
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+where every run has at least 50\% missing values for each peptide. FALSE is default.}
 
 \item{fix_missing}{Optional, same as the `fix_missing` parameter in MSstatsConvert::MSstatsBalancedDesign function}
 

--- a/man/dot-runTukey.Rd
+++ b/man/dot-runTukey.Rd
@@ -18,8 +18,8 @@ In this case, NA intensities are missing at random.
 The output from Skyline should use '0'. 
 Null assumes that all NA intensites are randomly missing.}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the runs 
-which have more than 50\% missing values. FALSE is default.}
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+where every run has at least 50\% missing values for each peptide. FALSE is default.}
 }
 \value{
 data.table


### PR DESCRIPTION
# Motivation and Context
I got questions regarding the remove50Missing parameter, and then realized that the documentation is a bit hard to follow and doesn't define the feature well.  Adjusted the parameter definition.

## Changes
- Adjusted the documentation regarding the `remove50Missing` parameter to be more clear on what it actually does.  
- Cleaned up documentation setup for MSstatsSummarize

## Testing
- Manuals have been updated with new information.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules