### PR TITLE
ci(dry-run): Set up dry run to use latest version of R and bioc + fix volcano plots

### DIFF
--- a/.github/workflows/dry-run-build.yml
+++ b/.github/workflows/dry-run-build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup R and Bioconductor
         uses: grimbough/bioc-actions/setup-bioc@v1
         with:
-          bioc-version: release
+          bioc-version: devel
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
       - name: Build, Install, Check

--- a/R/utils_groupcomparison_plots.R
+++ b/R/utils_groupcomparison_plots.R
@@ -203,7 +203,7 @@ colMin <- function(data) sapply(data, min, na.rm = TRUE)
                            limits = c(y.limdown, y.limup)) +
         labs(title = unique(label_name))
     plot = plot +
-        scale_x_continuous(paste0("Log", log_base_pval, " fold change"),
+        scale_x_continuous(paste0("Log", log_base_FC, " fold change"),
                            limits = c(-x.lim, x.lim))
     if (ProteinName) {
         if (!(length(unique(input$colgroup)) == 1 & any(unique(input$colgroup) == "black"))) {
@@ -237,12 +237,12 @@ colMin <- function(data) sapply(data, min, na.rm = TRUE)
     }
     if (is.numeric(FCcutoff)) {
         FCcutpos = data.table::setnames(data.table("sigline", 
-                                                   log(FCcutoff, log_base_pval), 
+                                                   log(FCcutoff, log_base_FC), 
                                                    seq(y.limdown, y.limup, length.out = 10), 
                                                    "dotted"),
                                         c("Protein", "logFC", log_adjp, "line"))
         FCcutneg = data.table::setnames(data.table("sigline", 
-                                                   (-log(FCcutoff, log_base_pval)), 
+                                                   (-log(FCcutoff, log_base_FC)), 
                                                    seq(y.limdown, y.limup, length.out = 10), 
                                                    "dotted"),
                                         c("Protein", "logFC", log_adjp, "line"))


### PR DESCRIPTION
# Motivation and Context

We're getting dry run [issues](https://github.com/Vitek-Lab/MSstats/actions/runs/9131303226).  I couldn't reproduce the issue locally, so I suspect there's an issue with the environment of R we're running with.

We also ran into an issue during May Institute where volcano plots have an x-axis label of log10 fold change despite using log2 fold change.  FC cutoff labels were also based on log 10 instead of log 2.

## Changes
- Fixed code to use the log FC base rather than the log p-value base for volcano plot labels.
- Update bioc version used in dry run builds.  The mapping can be found [here](https://github.com/grimbough/bioc-actions/blob/v1-branch/setup-bioc/bioc-version-map.csv)

## Testing
- Verified plots look correct locally
- Build runs correctly

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules