### PR TITLE
fix(groupComparison): Fix .checkTechReplicate function to return true if any tech replicates exist

### DIFF
--- a/R/utils_groupcomparison_checks.R
+++ b/R/utils_groupcomparison_checks.R
@@ -62,5 +62,5 @@
                                                               sep = "."))])
     run_counts = unique_annot[, list(NumRuns = data.table::uniqueN(RUN)),
                               by = "SUBJECT_NESTED"]
-    any(run_counts$NumRuns != 1)
+    any(run_counts[["NumRuns"]] > 1)
 }

--- a/R/utils_groupcomparison_checks.R
+++ b/R/utils_groupcomparison_checks.R
@@ -62,5 +62,5 @@
                                                               sep = "."))])
     run_counts = unique_annot[, list(NumRuns = data.table::uniqueN(RUN)),
                               by = "SUBJECT_NESTED"]
-    all(run_counts$NumRuns != 1)
+    any(run_counts$NumRuns != 1)
 }

--- a/inst/tinytest/test_utils_groupcomparison_checks.R
+++ b/inst/tinytest/test_utils_groupcomparison_checks.R
@@ -1,0 +1,32 @@
+# Test .checkTechReplicate ------------------------------------------------
+
+# Test 1: No technical replicates
+input = data.table::data.table(GROUP = c("A", "A", "B", "B"),
+                               RUN = c(1, 2, 3, 4),
+                               SUBJECT = c(1, 2, 3, 4))
+expect_false(MSstats:::.checkTechReplicate(input))
+
+# Test 2: Repeated Measures - No technical replicates
+input = data.table::data.table(GROUP = c("A", "A", "B", "B"),
+                               RUN = c(1, 2, 3, 4),
+                               SUBJECT = c(1, 2, 1, 2))
+expect_false(MSstats:::.checkTechReplicate(input))
+
+# Test 3: Technical replicates for one subject
+input = data.table::data.table(GROUP = c("A", "A", "B", "B"),
+                               RUN = c(1, 2, 3, 4),
+                               SUBJECT = c(1, 1, 2, 3))
+expect_true(MSstats:::.checkTechReplicate(input))
+
+# Test 4: Technical replicates for all subjects
+input = data.table::data.table(GROUP = c("A", "A", "B", "B"),
+                               RUN = c(1, 2, 3, 4),
+                               SUBJECT = c(1, 1, 2, 2))
+expect_true(MSstats:::.checkTechReplicate(input))
+
+# Test 5: Repeated Measures - Technical replicates
+input = data.table::data.table(GROUP = c("A", "A", "B", "B", "B"),
+                               RUN = c(1, 2, 3, 4, 5),
+                               SUBJECT = c(1, 2, 1, 2, 2))
+expect_true(MSstats:::.checkTechReplicate(input))
+


### PR DESCRIPTION
# Motivation and Context

A user pointed out an [issue](https://github.com/Vitek-Lab/MSstats/issues/131) where the .checkTechReplicate function returns FALSE unexpectedly despite there being technical replicates in an experiment.  Looking into it, .checkTechReplicate [returns true](https://github.com/Vitek-Lab/MSstats/blob/6d3a9666bb19df199ba7de0a0d0df557b7afd237/R/utils_groupcomparison_checks.R#L65) if `all` SUBJECT+GROUP combinations have > 1 run, but it should return true if `any` SUBJECT+GROUP combinations have > 1 run.  Otherwise, we end up fitting the wrong model [here](https://github.com/Vitek-Lab/MSstats/blob/6d3a9666bb19df199ba7de0a0d0df557b7afd237/R/utils_groupcomparison.R#L142-L1540), e.g. fitting a linear model instead of a linear mixed effects model where the subject is the random effect.

## Changes

- Modify .checkTechReplicate to return true if `any` SUBJECT+GROUP combinations have > 1 run. 

## Testing

- Added unit tests for .checkTechReplicate

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules