### PR TITLE
docs(dataProcess+groupComparison): Add documentation on output tables of dataProcess and groupComparison

### DIFF
--- a/R/dataProcess.R
+++ b/R/dataProcess.R
@@ -55,7 +55,45 @@
 #' @inheritParams .documentFunction
 #' 
 #' @importFrom utils sessionInfo
-#' @importFrom data.table as.data.table 
+#' @importFrom data.table as.data.table
+#' 
+#' @return A list containing:
+#' \describe{
+#'   \item{FeatureLevelData}{A data frame with feature-level information after processing. Columns include:
+#'     \describe{
+#'       \item{PROTEIN}{Identifier for the protein associated with the feature.}
+#'       \item{PEPTIDE}{Identifier for the peptide sequence.}
+#'       \item{TRANSITION}{Identifier for the transition, typically representing a specific ion pair.}
+#'       \item{FEATURE}{Unique identifier for the feature, which could be a combination of peptide and transition.}
+#'       \item{LABEL}{Specifies the isotopic labeling of peptides, notably for SRM-based experiments. "L" indicates light-labeled peptides while "H" denotes heavy-labeled peptides.}
+#'       \item{GROUP}{Experimental group identifier.}
+#'       \item{RUN}{Identifier for the specific MS run.}
+#'       \item{SUBJECT}{Subject identifier within the experimental group.}
+#'       \item{FRACTION}{Fraction identifier if fractionation was performed.}
+#'       \item{originalRUN}{Original run identifier before any processing.}
+#'       \item{censored}{Logical indicator of whether the intensity value is considered missing or below limit of detection.}
+#'       \item{INTENSITY}{Original intensity measurement of the feature in the given run.}
+#'       \item{ABUNDANCE}{Processed abundance or intensity value after log-transformation and normalization.}
+#'       \item{newABUNDANCE}{The ABUNDANCE column but includes imputed missing values. It is the column that is used for protein summarization.}
+#'       \item{predicted}{Predicted intensity values for censored data, typically derived from a statistical model.}
+#'     }
+#'   }
+#'   \item{ProteinLevelData}{A data frame with run-level summarized information for each protein. Columns include:
+#'     \describe{
+#'       \item{RUN}{Identifier for the specific MS run.}
+#'       \item{Protein}{Identifier for the protein.}
+#'       \item{LogIntensities}{Log-transformed intensities for the protein in each run.}
+#'       \item{originalRUN}{Original run identifier before any processing.}
+#'       \item{GROUP}{Experimental group identifier.}
+#'       \item{SUBJECT}{Subject identifier within the experimental group.}
+#'       \item{TotalGroupMeasurements}{Total number of feature measurements for the protein in the given group.}
+#'       \item{NumMeasuredFeatures}{Number of features measured for the protein in the given run.}
+#'       \item{MissingPercentage}{Percentage of missing feature values for the protein in the given run.}
+#'       \item{more50missing}{Logical indicator of whether more than 50 percent of the features values are missing for the protein in the given run.}
+#'       \item{NumImputedFeature}{Number of features for which values were imputed due to missing or censored data for the protein in the given run.}
+#'     }
+#'   }
+#' }
 #' 
 #' @export
 #' 

--- a/R/groupComparison.R
+++ b/R/groupComparison.R
@@ -15,8 +15,42 @@
 #' The underlying model fitting functions are lm and lmer for the fixed effects model and mixed effects model, respectively.
 #' The input of this function is the quantitative data from function (dataProcess).
 #'
-#' @return list that consists of three elements: "ComparisonResult" - data.frame with results of statistical testing,
-#' "ModelQC" - data.frame with data used to fit models for group comparison and "FittedModel" - list of fitted models.
+#' @return A list with the following components:
+#' \describe{
+#'   \item{ComparisonResult}{A `data.frame` containing the results of the statistical testing for each protein. The columns include:
+#'     \describe{
+#'       \item{Protein}{The name of the protein for which the comparison is made.}
+#'       \item{Label}{The label of the comparison, typically derived from the `contrast.matrix`.}
+#'       \item{log2FC}{The log2 fold change between the conditions being compared. The base of the logarithm is specified by the `log_base` parameter.}
+#'       \item{SE}{The standard error of the log2 fold change estimate.}
+#'       \item{Tvalue}{The t-statistic value for the comparison.}
+#'       \item{DF}{The degrees of freedom associated with the t-statistic.}
+#'       \item{pvalue}{The p-value for the statistical test of the comparison.}
+#'       \item{adj.pvalue}{The adjusted p-value using the Benjamini-Hochberg method for controlling the false discovery rate.}
+#'       \item{issue}{Any issues encountered during the comparison.  NA indicates no issues. "oneConditionMissing" occurs when data for one of the conditions being compared is entirely missing for a particular protein.}
+#'       \item{MissingPercentage}{The percentage of missing features for a given protein across all runs. This column is included only if missing values were imputed.}
+#'       \item{ImputationPercentage}{The percentage of features that were imputed for a given protein across all runs. This column is included only if missing values were imputed.}
+#'     }
+#'   }
+#'   \item{ModelQC}{A `data.frame` containing quality control data used to fit models for group comparison. The columns include:
+#'     \describe{
+#'       \item{RUN}{Identifier for the specific MS run.}
+#'       \item{Protein}{Identifier for the protein.}
+#'       \item{ABUNDANCE}{Summarized intensity for the protein in a given run.}
+#'       \item{originalRUN}{Original run identifier before any processing.}
+#'       \item{GROUP}{Experimental group identifier.}
+#'       \item{SUBJECT}{Subject identifier within the experimental group.}
+#'       \item{TotalGroupMeasurements}{Total number of feature measurements for the protein in the given group.}
+#'       \item{NumMeasuredFeatures}{Number of features measured for the protein in the given run.}
+#'       \item{MissingPercentage}{Percentage of missing feature values for the protein in the given run.}
+#'       \item{more50missing}{Logical indicator of whether more than 50 percent of the features values are missing for the protein in the given run.}
+#'       \item{NumImputedFeature}{Number of features for which values were imputed due to missing or censored data for the protein in the given run.}
+#'       \item{residuals}{Contains the differences between the observed values and the values predicted by the fitted model. }
+#'       \item{fitted}{The predicted values obtained from the model for a protein measurement for a given run in the dataset. }
+#'     }
+#'   }
+#'   \item{FittedModel}{A list of fitted models for each protein. This is included only if `save_fitted_models` is set to TRUE. Each element of the list corresponds to a protein and contains the fitted model object.}
+#' }
 #' 
 #' @export 
 #' @import lme4

--- a/man/dataProcess.Rd
+++ b/man/dataProcess.Rd
@@ -110,6 +110,45 @@ If `append = TRUE`, has to be a valid path to a file.}
 a logfile named `MSstats_dataProcess_log_progress.log` is created to 
 track progress. Only works for Linux & Mac OS. Default is 1.}
 }
+\value{
+A list containing:
+\describe{
+  \item{FeatureLevelData}{A data frame with feature-level information after processing. Columns include:
+    \describe{
+      \item{PROTEIN}{Identifier for the protein associated with the feature.}
+      \item{PEPTIDE}{Identifier for the peptide sequence.}
+      \item{TRANSITION}{Identifier for the transition, typically representing a specific ion pair.}
+      \item{FEATURE}{Unique identifier for the feature, which could be a combination of peptide and transition.}
+      \item{LABEL}{Specifies the isotopic labeling of peptides, notably for SRM-based experiments. "L" indicates light-labeled peptides while "H" denotes heavy-labeled peptides.}
+      \item{GROUP}{Experimental group identifier.}
+      \item{RUN}{Identifier for the specific MS run.}
+      \item{SUBJECT}{Subject identifier within the experimental group.}
+      \item{FRACTION}{Fraction identifier if fractionation was performed.}
+      \item{originalRUN}{Original run identifier before any processing.}
+      \item{censored}{Logical indicator of whether the intensity value is considered missing or below limit of detection.}
+      \item{INTENSITY}{Original intensity measurement of the feature in the given run.}
+      \item{ABUNDANCE}{Processed abundance or intensity value after log-transformation and normalization.}
+      \item{newABUNDANCE}{The ABUNDANCE column but includes imputed missing values. It is the column that is used for protein summarization.}
+      \item{predicted}{Predicted intensity values for censored data, typically derived from a statistical model.}
+    }
+  }
+  \item{ProteinLevelData}{A data frame with run-level summarized information for each protein. Columns include:
+    \describe{
+      \item{RUN}{Identifier for the specific MS run.}
+      \item{Protein}{Identifier for the protein.}
+      \item{LogIntensities}{Log-transformed intensities for the protein in each run.}
+      \item{originalRUN}{Original run identifier before any processing.}
+      \item{GROUP}{Experimental group identifier.}
+      \item{SUBJECT}{Subject identifier within the experimental group.}
+      \item{TotalGroupMeasurements}{Total number of feature measurements for the protein in the given group.}
+      \item{NumMeasuredFeatures}{Number of features measured for the protein in the given run.}
+      \item{MissingPercentage}{Percentage of missing feature values for the protein in the given run.}
+      \item{more50missing}{Logical indicator of whether more than 50 percent of the features values are missing for the protein in the given run.}
+      \item{NumImputedFeature}{Number of features for which values were imputed due to missing or censored data for the protein in the given run.}
+    }
+  }
+}
+}
 \description{
 Process MS data: clean, normalize and summarize before differential analysis
 }

--- a/man/groupComparison.Rd
+++ b/man/groupComparison.Rd
@@ -45,8 +45,42 @@ a logfile named `MSstats_groupComparison_log_progress.log` is created to
 track progress. Only works for Linux & Mac OS. Default is 1.}
 }
 \value{
-list that consists of three elements: "ComparisonResult" - data.frame with results of statistical testing,
-"ModelQC" - data.frame with data used to fit models for group comparison and "FittedModel" - list of fitted models.
+A list with the following components:
+\describe{
+  \item{ComparisonResult}{A `data.frame` containing the results of the statistical testing for each protein. The columns include:
+    \describe{
+      \item{Protein}{The name of the protein for which the comparison is made.}
+      \item{Label}{The label of the comparison, typically derived from the `contrast.matrix`.}
+      \item{log2FC}{The log2 fold change between the conditions being compared. The base of the logarithm is specified by the `log_base` parameter.}
+      \item{SE}{The standard error of the log2 fold change estimate.}
+      \item{Tvalue}{The t-statistic value for the comparison.}
+      \item{DF}{The degrees of freedom associated with the t-statistic.}
+      \item{pvalue}{The p-value for the statistical test of the comparison.}
+      \item{adj.pvalue}{The adjusted p-value using the Benjamini-Hochberg method for controlling the false discovery rate.}
+      \item{issue}{Any issues encountered during the comparison.  NA indicates no issues. "oneConditionMissing" occurs when data for one of the conditions being compared is entirely missing for a particular protein.}
+      \item{MissingPercentage}{The percentage of missing features for a given protein across all runs. This column is included only if missing values were imputed.}
+      \item{ImputationPercentage}{The percentage of features that were imputed for a given protein across all runs. This column is included only if missing values were imputed.}
+    }
+  }
+  \item{ModelQC}{A `data.frame` containing quality control data used to fit models for group comparison. The columns include:
+    \describe{
+      \item{RUN}{Identifier for the specific MS run.}
+      \item{Protein}{Identifier for the protein.}
+      \item{ABUNDANCE}{Summarized intensity for the protein in a given run.}
+      \item{originalRUN}{Original run identifier before any processing.}
+      \item{GROUP}{Experimental group identifier.}
+      \item{SUBJECT}{Subject identifier within the experimental group.}
+      \item{TotalGroupMeasurements}{Total number of feature measurements for the protein in the given group.}
+      \item{NumMeasuredFeatures}{Number of features measured for the protein in the given run.}
+      \item{MissingPercentage}{Percentage of missing feature values for the protein in the given run.}
+      \item{more50missing}{Logical indicator of whether more than 50 percent of the features values are missing for the protein in the given run.}
+      \item{NumImputedFeature}{Number of features for which values were imputed due to missing or censored data for the protein in the given run.}
+      \item{residuals}{Contains the differences between the observed values and the values predicted by the fitted model. }
+      \item{fitted}{The predicted values obtained from the model for a protein measurement for a given run in the dataset. }
+    }
+  }
+  \item{FittedModel}{A list of fitted models for each protein. This is included only if `save_fitted_models` is set to TRUE. Each element of the list corresponds to a protein and contains the fitted model object.}
+}
 }
 \description{
 Whole plot testing


### PR DESCRIPTION
### **User description**
# Motivation and Context

We've been getting a good amount of [questions](https://groups.google.com/g/msstats/search?q=MissingPercentage) on the MSstats google groups on what certain columns mean in the output of dataProcess and groupComparison.  We should add documentation.


## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files


___

### **PR Type**
Documentation


___

### **Description**
- Added comprehensive documentation for the `dataProcess` function, detailing the structure and columns of the `FeatureLevelData` and `ProteinLevelData` return values.
- Enhanced the `groupComparison` function documentation by describing the components of the return value, including `ComparisonResult`, `ModelQC`, and `FittedModel`.
- Updated the corresponding Rd files to reflect these documentation improvements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataProcess.R</strong><dd><code>Add detailed return value documentation for `dataProcess` function</code></dd></summary>
<hr>

R/dataProcess.R

<li>Added detailed documentation for the return value of the <code>dataProcess</code> <br>function.<br> <li> Described the structure and columns of <code>FeatureLevelData</code> and <br><code>ProteinLevelData</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/142/files#diff-321480d21bdc578dd9994bb29f9dcff991db1d3a4ae029079fc567e5a2eaaabc">+39/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>groupComparison.R</strong><dd><code>Add detailed return value documentation for <code>groupComparison</code> function</code></dd></summary>
<hr>

R/groupComparison.R

<li>Added detailed documentation for the return value of the <br><code>groupComparison</code> function.<br> <li> Described the structure and columns of <code>ComparisonResult</code>, <code>ModelQC</code>, and <br><code>FittedModel</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/142/files#diff-78b6c05b99c2091421cda250299bc5c6dc31033d6db7787a48859a20aeabe8da">+36/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dataProcess.Rd</strong><dd><code>Update documentation for `dataProcess` function return value</code></dd></summary>
<hr>

man/dataProcess.Rd

<li>Updated documentation to include detailed description of the return <br>value.<br> <li> Described the structure and columns of <code>FeatureLevelData</code> and <br><code>ProteinLevelData</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/142/files#diff-1747362a46e443c4fb2e55547ec9d99da5f7108727ed6f9cc8173c502db37fdd">+39/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>groupComparison.Rd</strong><dd><code>Update documentation for `groupComparison` function return value</code></dd></summary>
<hr>

man/groupComparison.Rd

<li>Updated documentation to include detailed description of the return <br>value.<br> <li> Described the structure and columns of <code>ComparisonResult</code>, <code>ModelQC</code>, and <br><code>FittedModel</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/142/files#diff-e6468161642bcb7a9995d6eb4cfa23d4e3e60703babe93986987055bc0d55a32">+36/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information