### PR TITLE
fix(linear-summarization): Fix segfault bug in get_linear_summary

### DIFF
--- a/src/linear_summary.cpp
+++ b/src/linear_summary.cpp
@@ -85,7 +85,7 @@ NumericVector get_feature_run(NumericVector find_runs, NumericVector find_featur
     NumericVector find_run_feature = intersect(find_runs, find_features);
     int n_rows = counts.nrow();
     NumericVector rf(0);
-    if ((find_run_feature.length() != 0) & !(find_run_feature[0] == -1)) {
+    if ((find_run_feature.length() != 0) && !(find_run_feature[0] == -1)) {
         CharacterVector temp_rf = coef_names[find_run_feature];
         rf = rep(1 / n_rows, temp_rf.length());
         rf.attr("names") = temp_rf;


### PR DESCRIPTION
This [dry run build](https://github.com/Vitek-Lab/MSstats/actions/runs/12643679623) is failing due to a segfault that is only caught in the CI/CD workflow.  It seems that the issue is the use of single `&` instead of double `&&` to perform boolean IF statement checks.  See this [post](https://stackoverflow.com/questions/8167249/if-condition-with-single-and) on the differences and why it matters.

Just remember that if you encounter a problem in life, even a segfault, you can do anything.  You can even fly.