### PR TITLE
Fix data.table bug in .logMissingness after data.table 1.17 update

### DIFF
--- a/R/utils_statistics.R
+++ b/R/utils_statistics.R
@@ -143,16 +143,23 @@
     ABUNDANCE = AllMissing = NumMissing = NumTotal = AnyAllMissing = NULL
     FEATURE = FractionMissing = RUN = NULL
     
-    missing = input[, list(NumMissing = sum(is.na(ABUNDANCE), na.rm = TRUE),
-                           NumTotal = .N), 
-                    by = c("LABEL", "GROUP", "FEATURE")]
-    missing[, AllMissing := NumMissing == NumTotal]
-    missing[, AnyAllMissing := any(AllMissing), by = c("LABEL", "FEATURE")]
+    input[, is_na_abundance := is.na(ABUNDANCE)]
+    missing = input[, .(
+        NumMissing = sum(is_na_abundance),
+        NumTotal = .N
+    ), by = .(LABEL, GROUP, FEATURE)]
+    missing[, AllMissing := (NumMissing == NumTotal)]
+    any_all_missing = missing[AllMissing == TRUE, 
+                              .(AnyAllMissing = TRUE), 
+                              by = .(LABEL, FEATURE)]
+    missing = merge(missing, any_all_missing, 
+                    by = c("LABEL", "FEATURE"), all.x = TRUE)
+    missing[is.na(AnyAllMissing), AnyAllMissing := FALSE]
     missing_in_any = as.character(missing[(AnyAllMissing), FEATURE])
-    # TODO: LOG, which features have AnyAllMissing
-    
-    missing_by_run = input[, list(NumMissing = sum(is.na(ABUNDANCE), na.rm = TRUE),
-                                  NumTotal = .N), by = "RUN"]
+    missing_by_run = input[, .(
+        NumMissing = sum(is_na_abundance),
+        NumTotal = .N
+    ), by = "RUN"]
     missing_by_run[, FractionMissing := NumMissing / NumTotal]
     missing_by_run = as.character(missing_by_run[FractionMissing > 0.75, 
                                                  unique(RUN)])

--- a/inst/tinytest/test_utils_statistics.R
+++ b/inst/tinytest/test_utils_statistics.R
@@ -4,24 +4,33 @@ options(MSstatsLog = function(level, msg) logged_msgs <<- c(logged_msgs, msg))
 options(MSstatsMsg = function(level, msg) {})  # no-op
 
 input <- data.table::data.table(
-  LABEL = rep(c("A", "B"), each = 4),
-  GROUP = rep(c("G1", "G2"), each = 2, times = 2),
-  FEATURE = c(rep("F1", 4), rep("F2", 4)),
-  ABUNDANCE = c(NA, NA, 1.2, 1.4, NA, NA, NA, NA),  # F2 is fully NA in all rows
-  RUN = paste0("R", 1:8)
+  LABEL = rep(c("L", "H"), each = 12),
+  GROUP = rep(c("Control", "Treated"), each = 6, times = 2),
+  FEATURE = rep(c("FEATURE1", "FEATURE2", "FEATURE3"), times = 8),
+  RUN = rep(paste0("Run", 1:4), each = 3, times = 2),
+  ABUNDANCE = c(
+    # Control group
+    10.5, 11.2,  NA,     # Run1
+    10.8,  NA,   NA,     # Run2 (2 missing)
+    11.0, 11.1, 11.2,    # Run3
+    NA,   NA,   NA,      # Run4 (fully missing)
+    # Treatment group
+    9.5, 9.8,   10.0,    # Run1
+    NA,   NA,   NA,      # Run2 (fully missing)
+    9.2, 9.3,    NA,     # Run3
+    NA,   NA,   NA       # Run4 (fully missing)
+  )
 )
 
 .logMissingness(input)
 
 expect_true(
-  any(grepl("Some features are completely missing.*F2", logged_msgs)),
-  info = "Should log that F2 is completely missing in at least one condition"
+  any(grepl("Some features are completely missing.*PEPTIDE2|PEPTIDE3", logged_msgs)),
+  info = "Should log that at least one feature is completely missing in a condition"
 )
 
 expect_true(
-  any(grepl("more than 75% missing values.*R5", logged_msgs)) &&
-    any(grepl("R6", logged_msgs)) &&
-    any(grepl("R7", logged_msgs)) &&
-    any(grepl("R8", logged_msgs)),
-  info = "Should log that runs R5 to R8 have >75% missing"
+  any(grepl("more than 75% missing values.*Run4", logged_msgs)) &&
+    any(grepl("Run2", logged_msgs)),
+  info = "Should log that Run2 and Run4 have >75% missing"
 )

--- a/inst/tinytest/test_utils_statistics.R
+++ b/inst/tinytest/test_utils_statistics.R
@@ -1,0 +1,27 @@
+# Test .logMissingness
+logged_msgs <- list()
+options(MSstatsLog = function(level, msg) logged_msgs <<- c(logged_msgs, msg))
+options(MSstatsMsg = function(level, msg) {})  # no-op
+
+input <- data.table::data.table(
+  LABEL = rep(c("A", "B"), each = 4),
+  GROUP = rep(c("G1", "G2"), each = 2, times = 2),
+  FEATURE = c(rep("F1", 4), rep("F2", 4)),
+  ABUNDANCE = c(NA, NA, 1.2, 1.4, NA, NA, NA, NA),  # F2 is fully NA in all rows
+  RUN = paste0("R", 1:8)
+)
+
+.logMissingness(input)
+
+expect_true(
+  any(grepl("Some features are completely missing.*F2", logged_msgs)),
+  info = "Should log that F2 is completely missing in at least one condition"
+)
+
+expect_true(
+  any(grepl("more than 75% missing values.*R5", logged_msgs)) &&
+    any(grepl("R6", logged_msgs)) &&
+    any(grepl("R7", logged_msgs)) &&
+    any(grepl("R8", logged_msgs)),
+  info = "Should log that runs R5 to R8 have >75% missing"
+)

--- a/inst/tinytest/test_utils_statistics.R
+++ b/inst/tinytest/test_utils_statistics.R
@@ -1,36 +1,46 @@
 # Test .logMissingness
-logged_msgs <- list()
-options(MSstatsLog = function(level, msg) logged_msgs <<- c(logged_msgs, msg))
-options(MSstatsMsg = function(level, msg) {})  # no-op
+log_env <- new.env()
+log_env$messages <- character()
 
+## Override logging options with closures that update the environment
+options(MSstatsLog = function(level, msg) {
+    log_env$messages <- c(log_env$messages, msg)
+})
+options(MSstatsMsg = function(level, msg) {})  # optional no-op
+
+## Realistic test dataset
 input <- data.table::data.table(
-  LABEL = rep(c("L", "H"), each = 12),
-  GROUP = rep(c("Control", "Treated"), each = 6, times = 2),
-  FEATURE = rep(c("FEATURE1", "FEATURE2", "FEATURE3"), times = 8),
-  RUN = rep(paste0("Run", 1:4), each = 3, times = 2),
-  ABUNDANCE = c(
-    # Control group
-    10.5, 11.2,  NA,     # Run1
-    10.8,  NA,   NA,     # Run2 (2 missing)
-    11.0, 11.1, 11.2,    # Run3
-    NA,   NA,   NA,      # Run4 (fully missing)
-    # Treatment group
-    9.5, 9.8,   10.0,    # Run1
-    NA,   NA,   NA,      # Run2 (fully missing)
-    9.2, 9.3,    NA,     # Run3
-    NA,   NA,   NA       # Run4 (fully missing)
-  )
+    LABEL = rep(c("L", "H"), each = 12),
+    GROUP = rep(c("Control", "Treatment"), each = 6, times = 2),
+    FEATURE = rep(c("PEPTIDE1", "PEPTIDE2", "PEPTIDE3"), times = 8),
+    RUN = rep(paste0("Run", 1:4), each = 3, times = 2),
+    ABUNDANCE = c(
+        10.5, 11.2,  NA,     # Run1
+        10.8,  NA,   NA,     # Run2
+        11.0, 11.1, 11.2,    # Run3
+        NA,   NA,   NA,      # Run4
+        9.5, 9.8,   10.0,    # Run1
+        NA,   NA,   NA,      # Run2
+        9.2, 9.3,    NA,     # Run3
+        NA,   NA,   NA       # Run4
+    )
 )
 
+## Run the function
 MSstats:::.logMissingness(input)
 
+## Extract messages
+msgs <- log_env$messages
+
+## Feature-level logging check
 expect_true(
-  any(grepl("Some features are completely missing.*PEPTIDE2|PEPTIDE3", logged_msgs)),
-  info = "Should log that at least one feature is completely missing in a condition"
+    any(grepl("Some features are completely missing.*PEPTIDE", msgs)),
+    info = "Should log about completely missing features"
 )
 
+## Run-level logging check
 expect_true(
-  any(grepl("more than 75% missing values.*Run4", logged_msgs)) &&
-    any(grepl("Run2", logged_msgs)),
-  info = "Should log that Run2 and Run4 have >75% missing"
+    any(grepl("more than 75% missing values.*Run2", msgs)) &&
+        any(grepl("Run4", msgs)),
+    info = "Should log that Run2 and Run4 have >75% missing"
 )

--- a/inst/tinytest/test_utils_statistics.R
+++ b/inst/tinytest/test_utils_statistics.R
@@ -22,7 +22,7 @@ input <- data.table::data.table(
   )
 )
 
-.logMissingness(input)
+MSstats:::.logMissingness(input)
 
 expect_true(
   any(grepl("Some features are completely missing.*PEPTIDE2|PEPTIDE3", logged_msgs)),


### PR DESCRIPTION
# Motivation and Context

https://github.com/Vitek-Lab/MSstats/issues/162

Any operation with data.table 1.17+ where you perform an operation by a group can take a long time especially if there are many groups, e.g. the below code takes a long time to run because we're checking is.na(ABUNDANCE) for each FEATURE group, where there could be millions of features.  

```
input[, list(NumMissing = sum(is.na(ABUNDANCE), 
                                        na.rm = TRUE), NumTotal = .N), by = c("LABEL", "GROUP", 
                                                                              "FEATURE")]
```

## Changes

Refactor .logMissingness to properly do data.table operations in a scalable way.

## Testing

- Added unit tests and verified they pass before/after the change
- For a [dataset](https://ood.explorer.northeastern.edu/pun/sys/dashboard/files/fs//projects/VitekLab/Data/MS/Benchmarking/DDA-Solivais2024_Metamorpheus) with 157165 features, processing time of .logMissingness decreased from 14.32 seconds to 0.32 seconds.  Don't need a high sample size to know that this is significant.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files