### PR TITLE
fix(dataProcessPlots): Convert pixels to inches for pdf plots

### DIFF
--- a/R/dataProcessPlots.R
+++ b/R/dataProcessPlots.R
@@ -45,8 +45,8 @@
 #' above graph in Profile Plot. Default is 7.
 #' @param dot.size.profile size of dots in profile plot. Default is 2.
 #' @param dot.size.condition size of dots in condition plot. Default is 3.
-#' @param width width of the saved file. Default is 10.
-#' @param height height of the saved file. Default is 10.
+#' @param width width of the saved file in pixels. Default is 800 pixels.
+#' @param height height of the saved file in pixels. Default is 600 pixels.
 #' @param which.Protein Protein list to draw plots. List can be names of Proteins
 #' or order numbers of Proteins from levels(data$FeatureLevelData$PROTEIN).
 #' Default is "all", which generates all plots for each protein. 

--- a/R/groupComparisonPlots.R
+++ b/R/groupComparisonPlots.R
@@ -26,8 +26,8 @@
 #' @param numProtein For ggplot2: The number of proteins which will be presented in each heatmap. Default is 100. Maximum possible number of protein for one heatmap is 180.
 #' For Plotly: use this parameter to adjust the number of proteins to be displayed on the heatmap 
 #' @param clustering Determines how to order proteins and comparisons. Hierarchical cluster analysis with Ward method(minimum variance) is performed. 'protein' means that protein dendrogram is computed and reordered based on protein means (the order of row is changed). 'comparison' means comparison dendrogram is computed and reordered based on comparison means (the order of comparison is changed). 'both' means to reorder both protein and comparison. Default is 'protein'.
-#' @param width width of the saved file. Default is 10.
-#' @param height height of the saved file. Default is 10.
+#' @param width width of the saved file in pixels. Default is 800.
+#' @param height height of the saved file in pixels. Default is 600.
 #' @param which.Comparison list of comparisons to draw plots. List can be labels of comparisons or order numbers of comparisons from levels(data$Label), such as levels(testResultMultiComparisons$ComparisonResult$Label). Default is "all", which generates all plots for each protein.
 #' @param which.Protein Protein list to draw comparison plots. List can be names of Proteins or order numbers of Proteins from levels(testResultMultiComparisons$ComparisonResult$Protein). Default is "all", which generates all comparison plots for each protein.
 #' @param address the name of folder that will store the results. Default folder is the current working directory. The other assigned folder has to be existed under the current working directory. An output pdf file is automatically created with the default name of "VolcanoPlot.pdf" or "Heatmap.pdf" or "ComparisonPlot.pdf". The command address can help to specify where to store the file as well as how to modify the beginning of the file name. If address=FALSE, plot will be not saved as pdf file but showed in window.

--- a/R/utils_plots_common.R
+++ b/R/utils_plots_common.R
@@ -99,11 +99,20 @@ getSelectedProteins = function(chosen_proteins, all_proteins) {
 #' 
 savePlot = function(name_base, file_name, width, height) {
     if (name_base != FALSE) {
-        file_path = getFileName(name_base, file_name, width, height)
+        width_inches = .convertPixelsToInches(width)
+        height_inches = .convertPixelsToInches(height)
+        file_path = getFileName(name_base, file_name, 
+                                width, height)
         file_path = paste0(file_path,".pdf")
-        pdf(file_path, width = width, height = height)
+        pdf(file_path, width = width_inches, height = height_inches)
     }
     NULL
+}
+
+.convertPixelsToInches = function(pixels) {
+    # Convert pixels to inches (using standard 72 DPI)
+    inches = pixels / 72
+    return(inches)
 }
 
 getFileName = function(name_base, file_name, width, height) {

--- a/man/dataProcessPlots.Rd
+++ b/man/dataProcessPlots.Rd
@@ -79,9 +79,9 @@ above graph in Profile Plot. Default is 7.}
 
 \item{dot.size.condition}{size of dots in condition plot. Default is 3.}
 
-\item{width}{width of the saved file. Default is 10.}
+\item{width}{width of the saved file in pixels. Default is 800 pixels.}
 
-\item{height}{height of the saved file. Default is 10.}
+\item{height}{height of the saved file in pixels. Default is 600 pixels.}
 
 \item{which.Protein}{Protein list to draw plots. List can be names of Proteins
 or order numbers of Proteins from levels(data$FeatureLevelData$PROTEIN).

--- a/man/dot-makeHeatmapPlotly.Rd
+++ b/man/dot-makeHeatmapPlotly.Rd
@@ -21,7 +21,7 @@
 
 \item{y.axis.size}{size of axes labels, e.g. name of targeted proteins in heatmap. Default is 10.}
 
-\item{height}{height of the saved file. Default is 10.}
+\item{height}{height of the saved file in pixels. Default is 600.}
 
 \item{numProtein}{For ggplot2: The number of proteins which will be presented in each heatmap. Default is 100. Maximum possible number of protein for one heatmap is 180.
 For Plotly: use this parameter to adjust the number of proteins to be displayed on the heatmap}

--- a/man/dot-plotComparison.Rd
+++ b/man/dot-plotComparison.Rd
@@ -26,9 +26,9 @@
 
 \item{address}{the name of folder that will store the results. Default folder is the current working directory. The other assigned folder has to be existed under the current working directory. An output pdf file is automatically created with the default name of "VolcanoPlot.pdf" or "Heatmap.pdf" or "ComparisonPlot.pdf". The command address can help to specify where to store the file as well as how to modify the beginning of the file name. If address=FALSE, plot will be not saved as pdf file but showed in window.}
 
-\item{width}{width of the saved file. Default is 10.}
+\item{width}{width of the saved file in pixels. Default is 800.}
 
-\item{height}{height of the saved file. Default is 10.}
+\item{height}{height of the saved file in pixels. Default is 600.}
 
 \item{sig}{FDR cutoff for the adjusted p-values in heatmap and volcano plot. level of significance for comparison plot. 100(1-sig)\% confidence interval will be drawn.  sig=0.05 is default.}
 

--- a/man/dot-plotHeatmap.Rd
+++ b/man/dot-plotHeatmap.Rd
@@ -40,9 +40,9 @@ For Plotly: use this parameter to adjust the number of proteins to be displayed 
 
 \item{colorkey}{TRUE(default) shows colorkey.}
 
-\item{width}{width of the saved file. Default is 10.}
+\item{width}{width of the saved file in pixels. Default is 800.}
 
-\item{height}{height of the saved file. Default is 10.}
+\item{height}{height of the saved file in pixels. Default is 600.}
 
 \item{log_base_FC}{log base for log-fold changes - 2 or 10}
 

--- a/man/dot-plotVolcano.Rd
+++ b/man/dot-plotVolcano.Rd
@@ -31,9 +31,9 @@
 
 \item{address}{the name of folder that will store the results. Default folder is the current working directory. The other assigned folder has to be existed under the current working directory. An output pdf file is automatically created with the default name of "VolcanoPlot.pdf" or "Heatmap.pdf" or "ComparisonPlot.pdf". The command address can help to specify where to store the file as well as how to modify the beginning of the file name. If address=FALSE, plot will be not saved as pdf file but showed in window.}
 
-\item{width}{width of the saved file. Default is 10.}
+\item{width}{width of the saved file in pixels. Default is 800.}
 
-\item{height}{height of the saved file. Default is 10.}
+\item{height}{height of the saved file in pixels. Default is 600.}
 
 \item{ylimUp}{for all three plots, upper limit for y-axis. FALSE (default) for volcano plot/heatmap use maximum of -log2 (adjusted p-value) or -log10 (adjusted p-value). FALSE (default) for comparison plot uses maximum of log-fold change + CI.}
 

--- a/man/groupComparisonPlots.Rd
+++ b/man/groupComparisonPlots.Rd
@@ -69,9 +69,9 @@ For Plotly: use this parameter to adjust the number of proteins to be displayed 
 
 \item{clustering}{Determines how to order proteins and comparisons. Hierarchical cluster analysis with Ward method(minimum variance) is performed. 'protein' means that protein dendrogram is computed and reordered based on protein means (the order of row is changed). 'comparison' means comparison dendrogram is computed and reordered based on comparison means (the order of comparison is changed). 'both' means to reorder both protein and comparison. Default is 'protein'.}
 
-\item{width}{width of the saved file. Default is 10.}
+\item{width}{width of the saved file in pixels. Default is 800.}
 
-\item{height}{height of the saved file. Default is 10.}
+\item{height}{height of the saved file in pixels. Default is 600.}
 
 \item{which.Comparison}{list of comparisons to draw plots. List can be labels of comparisons or order numbers of comparisons from levels(data$Label), such as levels(testResultMultiComparisons$ComparisonResult$Label). Default is "all", which generates all plots for each protein.}
 


### PR DESCRIPTION
### **User description**
# Motivation and Context

The default options for `dataProcessPlots` and `groupComparisonPlots` for saving PDFs into our local directory are faulty w.r.t. width and height because the defaults are in pixels, whereas the `pdf` function expects inches.  This leads to PDFs where everything is improperly formatted and spaced.

## Changes

- Keep the unit type of `width` and `height` the same (pixels), but add a converter for pixels to inches before sending those values to the `pdf` function.

## Testing

- Verified manually that I had no issue producing pdfs for profile and qc plots
- No changes occurred with plotly plots

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files


___

### **PR Type**
Enhancement


___

### **Description**
- Specify plot width/height parameters in pixels

- Add .convertPixelsToInches utility for conversion

- Apply conversion in savePlot before pdf() call

- Update documentation across plot functions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>dataProcessPlots.R</strong><dd><code>Specify plot width/height in pixels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-6c7d294cb029339cc59d5c8dcf58cb44fda17c5666b1173dc709533f139b3596">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>groupComparisonPlots.R</strong><dd><code>Specify plot width/height in pixels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-3da455d0cc08a77d4977df23205500d5b78875bc08cfa1212f8d4c4ce7ac912e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dataProcessPlots.Rd</strong><dd><code>Update width/height docs to pixels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-5e20e7095e740d5fd5ec8e43eb880b83be3fae9536dc5947da5a5de651a09145">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dot-makeHeatmapPlotly.Rd</strong><dd><code>Update height parameter docs to pixels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-931603fb426a1ac79445d695428763f79ad4b098fcfa7335ef378cf118bebdf2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dot-plotComparison.Rd</strong><dd><code>Update width/height docs to pixels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-9c8ac2029c169db13fc7a29ee8612d6deebbf61a884dfe9efd377a8dd195aedb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dot-plotHeatmap.Rd</strong><dd><code>Update width/height docs to pixels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-741b012d3bd4e9368fd5c20ecaa5aa6531a15aa5dc1f9e1ddeacaa90db745dae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dot-plotVolcano.Rd</strong><dd><code>Update width/height docs to pixels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-36d56fd13b9161d9154649c5a10c1d4191656adba8cfc4771b5ad258cb95bf75">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>groupComparisonPlots.Rd</strong><dd><code>Update width/height docs to pixels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-9465a29c36bc9f9d4cd00b4ebb657847ee84fede5184ff2d652693cc2bbcfce1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>utils_plots_common.R</strong><dd><code>Add pixel-to-inch conversion and apply</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/167/files#diff-fefc26f291ee7fc52b3fcfbd04106c1133d643882568160b253bdec90665e031">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that plot dimension parameters (`width` and `height`) are specified in pixels, with updated default values (800 for width, 600 for height) across relevant functions and documentation.
* **Refactor**
  * Improved plot saving to accurately convert pixel dimensions to inches for file output, ensuring consistent sizing in saved plots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->