### PR TITLE
changed default to topN with 100 features

### DIFF
--- a/R/dataProcess.R
+++ b/R/dataProcess.R
@@ -12,9 +12,9 @@
 #' recommendations on which normalization option to use.
 #' @param nameStandards optional vector of global standard peptide names. 
 #' Required only for normalization with global standard peptides.
-#' @param featureSubset "all" (default) uses all features that the data set has. 
+#' @param featureSubset "topN" (default) uses top N features which has highest average of log-intensity across runs. 
 #' "top3" uses top 3 features which have highest average of log-intensity across runs. 
-#' "topN" uses top N features which has highest average of log-intensity across runs. 
+#' "all" uses all features that the data set has (not recommended in DIA experiments).
 #' It needs the input for n_top_feature option. 
 #' "highQuality" flags uninformative feature and outliers. See MSstats vignettes for 
 #' recommendations on which feature selection option to use.
@@ -27,9 +27,11 @@
 #' @param min_feature_count optional. Only required if featureSubset = "highQuality".
 #' Defines a minimum number of informative features a protein needs to be considered
 #' in the feature selection algorithm.
-#' @param n_top_feature optional. Only required if featureSubset = 'topN'.  
-#' It that case, it specifies number of top features that will be used.
-#' Default is 3, which means to use top 3 features.
+#' @param n_top_feature Specifies the number of top features to use in summarization (100 default). 
+#' Only required if featureSubset = 'topN'.  
+#' Default is 100, which means to use top 100 features. 
+#' Smaller numbers can be set to improve processing times. This option is by default on 
+#' at a high number (100) to improve processing times without affecting differential analysis.
 #' @param summaryMethod "TMP" (default) means Tukey's median polish, 
 #' which is robust estimation method. "linear" uses linear mixed model.
 #' @param equalFeatureVar only for summaryMethod = "linear". default is TRUE. 
@@ -119,8 +121,8 @@
 #' 
 dataProcess = function(
     raw, logTrans = 2, normalization = "equalizeMedians", nameStandards = NULL,
-    featureSubset = "all", remove_uninformative_feature_outlier = FALSE, 
-    min_feature_count = 2, n_top_feature = 3, summaryMethod = "TMP", 
+    featureSubset = "topN", remove_uninformative_feature_outlier = FALSE, 
+    min_feature_count = 2, n_top_feature = 100, summaryMethod = "TMP", 
     equalFeatureVar = TRUE, censoredInt = "NA", MBimpute = TRUE, 
     remove50missing = FALSE, fix_missing = NULL, maxQuantileforCensored = 0.999, 
     use_log_file = TRUE, append = FALSE, verbose = TRUE, log_file_path = NULL,

--- a/man/dataProcess.Rd
+++ b/man/dataProcess.Rd
@@ -9,10 +9,10 @@ dataProcess(
   logTrans = 2,
   normalization = "equalizeMedians",
   nameStandards = NULL,
-  featureSubset = "all",
+  featureSubset = "topN",
   remove_uninformative_feature_outlier = FALSE,
   min_feature_count = 2,
-  n_top_feature = 3,
+  n_top_feature = 100,
   summaryMethod = "TMP",
   equalFeatureVar = TRUE,
   censoredInt = "NA",
@@ -44,9 +44,9 @@ recommendations on which normalization option to use.}
 \item{nameStandards}{optional vector of global standard peptide names. 
 Required only for normalization with global standard peptides.}
 
-\item{featureSubset}{"all" (default) uses all features that the data set has. 
+\item{featureSubset}{"topN" (default) uses top N features which has highest average of log-intensity across runs. 
 "top3" uses top 3 features which have highest average of log-intensity across runs. 
-"topN" uses top N features which has highest average of log-intensity across runs. 
+"all" uses all features that the data set has (not recommended in DIA experiments).
 It needs the input for n_top_feature option. 
 "highQuality" flags uninformative feature and outliers. See MSstats vignettes for 
 recommendations on which feature selection option to use.}
@@ -62,9 +62,11 @@ for run-level summarization.}
 Defines a minimum number of informative features a protein needs to be considered
 in the feature selection algorithm.}
 
-\item{n_top_feature}{optional. Only required if featureSubset = 'topN'.
-It that case, it specifies number of top features that will be used.
-Default is 3, which means to use top 3 features.}
+\item{n_top_feature}{Specifies the number of top features to use in summarization (100 default). 
+Only required if featureSubset = 'topN'.  
+Default is 100, which means to use top 100 features. 
+Smaller numbers can be set to improve processing times. This option is by default on 
+at a high number (100) to improve processing times without affecting differential analysis.}
 
 \item{summaryMethod}{"TMP" (default) means Tukey's median polish, 
 which is robust estimation method. "linear" uses linear mixed model.}


### PR DESCRIPTION
### **User description**
# Motivation and Context

We recommend users use topN feature selection with a high N (e.g., 100) to speed up processing times in large DIA experiments. However this is not the default option and people end up having issues when using the default "all" option. Changing the default to TopN with 100 features will not impact DDA/SRM/PRM but will greatly speed up DIA experiments without having major impacts on the qualitative inference of differential analysis.

## Changes

- TopN feature selection now default
- n_top_feature now default to 100
- Updated documentation to reflect these changes

## Testing

No unit tests modified, all still pass.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- `featureSubset` default now `topN`

- `n_top_feature` default increased to 100

- Updated function signature defaults

- Synchronized documentation with code


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataProcess.R</strong><dd><code>Update dataProcess default parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/dataProcess.R

<ul><li>Changed <code>featureSubset</code> default to "topN"<br> <li> Updated <code>n_top_feature</code> default to 100<br> <li> Revised <code>@param</code> descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/169/files#diff-321480d21bdc578dd9994bb29f9dcff991db1d3a4ae029079fc567e5a2eaaabc">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataProcess.Rd</strong><dd><code>Align documentation with new defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

man/dataProcess.Rd

<ul><li>Changed <code>featureSubset</code> default to "topN"<br> <li> Increased <code>n_top_feature</code> default to 100<br> <li> Aligned Rd documentation with code defaults</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/169/files#diff-1747362a46e443c4fb2e55547ec9d99da5f7108727ed6f9cc8173c502db37fdd">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default settings for feature selection in data processing: now selects the top N features by default, with N set to 100.
* **Documentation**
  * Improved documentation to clarify feature selection options and updated default values for parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->