### PR TITLE
fix(groupcomparison): Fix .countMissingPercentage for custom contrast…

### DIFF
--- a/R/utils_groupcomparison.R
+++ b/R/utils_groupcomparison.R
@@ -406,7 +406,7 @@ getSamplesInfo = function(summarization_output) {
                                  NumImputedFeature = sum(NumImputedFeature, 
                                                          na.rm = TRUE)),
                             by = "GROUP"]
-        counts = counts[match(colnames(contrast_matrix), GROUP)]
+        counts <- counts[match(intersect(colnames(contrast_matrix), GROUP), GROUP), ]
     
     empty_conditions = setdiff(samples_info$GROUP, unique(counts$GROUP))
     if (length(empty_conditions) !=0) {

--- a/R/utils_groupcomparison.R
+++ b/R/utils_groupcomparison.R
@@ -406,6 +406,7 @@ getSamplesInfo = function(summarization_output) {
                                  NumImputedFeature = sum(NumImputedFeature, 
                                                          na.rm = TRUE)),
                             by = "GROUP"]
+        counts = counts[match(colnames(contrast_matrix), GROUP)]
     
     empty_conditions = setdiff(samples_info$GROUP, unique(counts$GROUP))
     if (length(empty_conditions) !=0) {

--- a/inst/tinytest/test_utils_groupcomparison.R
+++ b/inst/tinytest/test_utils_groupcomparison.R
@@ -3,7 +3,7 @@ library(data.table)
 # Test suite for .countMissingPercentage function
 ## Test 1: Basic functionality with no missing values
 contrast_matrix <- matrix(c(1, -1, 0, 
-                            0, 1, -1), nrow = 2, ncol = 3)
+                            0, 1, -1), nrow = 2, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
 
 summarized <- data.table(
@@ -78,7 +78,7 @@ expect_true(is.numeric(output$MissingPercentage), info = "Empty conditions: Nume
 
 contrast_matrix <- matrix(c(1, -1, 0, 
                             0, 1, -1, 
-                            1, 0, -1), nrow = 3, ncol = 3)
+                            1, 0, -1), nrow = 3, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group3", "Group2", "Group1")
 
 summarized <- data.table(
@@ -89,7 +89,10 @@ summarized <- data.table(
 )
 
 result <- list()
-samples_info <- data.table(GROUP = c("Group3", "Group2", "Group1"), NumRuns = c(1, 1, 1))
+samples_info <- data.table(
+    GROUP = c("Group3", "Group2", "Group1"), 
+    NumRuns = c(1, 1, 1)
+)
 
 # Execute
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
@@ -220,7 +223,7 @@ expect_true("MissingPercentage" %in% names(output), info = "Preserve existing: M
 # Complex contrast matrix with multiple non-zero values
 
 
-contrast_matrix <- matrix(c(1, 1, -2, 0.5, -0.5, 0), nrow = 2, ncol = 3)
+contrast_matrix <- matrix(c(0.5, 0.5, -1, 0.5, -0.5, 0), nrow = 2, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
 
 summarized <- data.table(

--- a/inst/tinytest/test_utils_groupcomparison.R
+++ b/inst/tinytest/test_utils_groupcomparison.R
@@ -74,7 +74,6 @@ expect_equal(length(output$MissingPercentage), 1, info = "Empty conditions: Miss
 expect_true(is.numeric(output$MissingPercentage), info = "Empty conditions: Numeric output")
 
 ## Test 4: Multiple contrasts with different missing patterns
-## THIS TEST IS FAILING, NEED TO MAKE SURE IT DOES NOT FAIL
 
 contrast_matrix <- matrix(c(1, -1, 0, 
                             0, 1, -1, 

--- a/inst/tinytest/test_utils_groupcomparison.R
+++ b/inst/tinytest/test_utils_groupcomparison.R
@@ -1,7 +1,7 @@
 library(data.table)
 
-# Test 1: Basic functionality with no missing values
-# Setup
+# Test suite for .countMissingPercentage function
+## Test 1: Basic functionality with no missing values
 contrast_matrix <- matrix(c(1, -1, 0, 
                             0, 1, -1), nrow = 2, ncol = 3)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
@@ -13,19 +13,26 @@ summarized <- data.table(
     NumImputedFeature = c(0, 0, 0, 0, 0, 0)
 )
 
-result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
-
-# Execute
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
-
-# Assert
+result <- data.table(
+    logFC = c(6.154384, 6.154384),
+    SE = c(0.2917031, 0.2917031),
+    Tvalue = c(21.09811, 21.09811),
+    DF = c(4, 4),
+    pvalue = c(0.0000381, 0.0000381),
+    Protein = c("IDHC", "IDHC"),
+    Label = c("Group1 - Group2", "Group2 - Group3"),
+    issue = c(NA, NA)
+)
+samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(2, 2, 2))
+output <- MSstats:::.countMissingPercentage(
+    contrast_matrix, summarized, result, samples_info, FALSE
+)
 expect_equal(length(output$MissingPercentage), 2, info = "Basic functionality: MissingPercentage length")
 expect_equal(output$MissingPercentage, c(0, 0), info = "Basic functionality: No missing values")
 expect_true(is.null(output$ImputationPercentage), info = "Basic functionality: No imputation when has_imputed = FALSE")
+expect_true(all(names(output) %in% c(names(result), "MissingPercentage")), info = "Basic functionality: Preserve existing result data")
 
-# Test 2: With imputed values
-# Setup
+## Test 2: With imputed values
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
 
@@ -38,19 +45,14 @@ summarized <- data.table(
 
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
-
-# Execute
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
-
-# Assert
 expected_missing <- 1 - (80 + 70) / (100 + 100) # 0.25
 expected_imputed <- (10 + 20) / (100 + 100) # 0.15
-
 expect_equal(output$MissingPercentage[1], expected_missing, info = "Imputed values: Missing percentage calculation")
 expect_equal(output$ImputationPercentage[1], expected_imputed, info = "Imputed values: Imputation percentage calculation")
 
-# Test 3: With empty conditions (groups not in summarized data)
-# Setup
+## Test 3: With empty conditions (groups not in summarized data)
+
 contrast_matrix <- matrix(c(1, -1, 0), nrow = 1, ncol = 3)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
 
@@ -64,17 +66,20 @@ summarized <- data.table(
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
 
-# Execute
+
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
 
-# Assert
+
 expect_equal(length(output$MissingPercentage), 1, info = "Empty conditions: MissingPercentage length")
 expect_true(is.numeric(output$MissingPercentage), info = "Empty conditions: Numeric output")
 
-# Test 4: Multiple contrasts with different missing patterns
-# Setup
-contrast_matrix <- matrix(c(1, -1, 0, 0, 1, -1, 1, 0, -1), nrow = 3, ncol = 3)
-colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
+## Test 4: Multiple contrasts with different missing patterns
+## THIS TEST IS FAILING, NEED TO MAKE SURE IT DOES NOT FAIL
+
+contrast_matrix <- matrix(c(1, -1, 0, 
+                            0, 1, -1, 
+                            1, 0, -1), nrow = 3, ncol = 3)
+colnames(contrast_matrix) <- c("Group3", "Group2", "Group1")
 
 summarized <- data.table(
     GROUP = c("Group1", "Group2", "Group3"),
@@ -84,19 +89,42 @@ summarized <- data.table(
 )
 
 result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
+samples_info <- data.table(GROUP = c("Group3", "Group2", "Group1"), NumRuns = c(1, 1, 1))
 
 # Execute
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 
-# Assert
-expect_equal(length(output$MissingPercentage), 3, info = "Multiple contrasts: MissingPercentage length")
-expect_equal(length(output$ImputationPercentage), 3, info = "Multiple contrasts: ImputationPercentage length")
-expect_true(all(output$MissingPercentage >= 0), info = "Multiple contrasts: MissingPercentage non-negative")
-expect_true(all(output$MissingPercentage <= 1), info = "Multiple contrasts: MissingPercentage <= 1")
+# Assert - Verify specific calculations for each contrast
+# Contrast 1: Group3 vs Group2 (1*Group3 + -1*Group2 + 0*Group1)
+# Groups involved: Group3 (70 measured, 100 total), Group2 (80 measured, 100 total)
+expected_missing_1 <- 1 - (70 + 80) / (100 + 100)  # 1 - 150/200 = 0.25
+expected_imputed_1 <- (15 + 10) / (100 + 100)      # 25/200 = 0.125
 
-# Test 5: Edge case with all values missing in one group
-# Setup
+# Contrast 2: Group2 vs Group1 (0*Group3 + 1*Group2 + -1*Group1)  
+# Groups involved: Group2 (80 measured, 100 total), Group1 (90 measured, 100 total)
+expected_missing_2 <- 1 - (80 + 90) / (100 + 100)  # 1 - 170/200 = 0.15
+expected_imputed_2 <- (10 + 5) / (100 + 100)       # 15/200 = 0.075
+
+# Contrast 3: Group3 vs Group1 (1*Group3 + 0*Group2 + -1*Group1)
+# Groups involved: Group3 (70 measured, 100 total), Group1 (90 measured, 100 total)  
+expected_missing_3 <- 1 - (70 + 90) / (100 + 100)  # 1 - 160/200 = 0.20
+expected_imputed_3 <- (15 + 5) / (100 + 100)       # 20/200 = 0.10
+
+expect_equal(length(output$MissingPercentage), 3, info = "Column ordering: MissingPercentage length")
+expect_equal(length(output$ImputationPercentage), 3, info = "Column ordering: ImputationPercentage length")
+
+# Verify exact calculations regardless of column order
+expect_equal(output$MissingPercentage[1], expected_missing_1, info = "Column ordering: Contrast 1 missing percentage (Group3 vs Group2)")
+expect_equal(output$ImputationPercentage[1], expected_imputed_1, info = "Column ordering: Contrast 1 imputation percentage")
+
+expect_equal(output$MissingPercentage[2], expected_missing_2, info = "Column ordering: Contrast 2 missing percentage (Group2 vs Group1)")
+expect_equal(output$ImputationPercentage[2], expected_imputed_2, info = "Column ordering: Contrast 2 imputation percentage")
+
+expect_equal(output$MissingPercentage[3], expected_missing_3, info = "Column ordering: Contrast 3 missing percentage (Group3 vs Group1)")
+expect_equal(output$ImputationPercentage[3], expected_imputed_3, info = "Column ordering: Contrast 3 imputation percentage")
+
+## Test 5: Edge case with all values missing in one group
+
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
 
@@ -110,15 +138,15 @@ summarized <- data.table(
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
 
-# Execute
+
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
 
-# Assert
+
 expected_missing <- 1 - (0 + 100) / (100 + 100) # 0.5
 expect_equal(output$MissingPercentage[1], expected_missing, info = "Complete missing group: Missing percentage calculation")
 
-# Test 6: Single group contrast
-# Setup
+## Test 6: Single group contrast
+
 contrast_matrix <- matrix(c(1, 0, 0), nrow = 1, ncol = 3)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
 
@@ -132,18 +160,18 @@ summarized <- data.table(
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
 
-# Execute
+
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 
-# Assert
+
 expected_missing <- 1 - 75 / 100 # Only Group1 is involved
 expected_imputed <- 10 / 100
 
 expect_equal(output$MissingPercentage[1], expected_missing, info = "Single group contrast: Missing percentage")
 expect_equal(output$ImputationPercentage[1], expected_imputed, info = "Single group contrast: Imputation percentage")
 
-# Test 7: Test with NA values in summarized data
-# Setup
+## Test 7: Test with NA values in summarized data
+
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
 
@@ -157,16 +185,16 @@ summarized <- data.table(
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
 
-# Execute
+
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 
-# Assert - should handle NA values with na.rm = TRUE
+
 expect_true(is.numeric(output$MissingPercentage), info = "NA values: Numeric MissingPercentage")
 expect_true(is.numeric(output$ImputationPercentage), info = "NA values: Numeric ImputationPercentage")
 expect_equal(length(output$MissingPercentage), 1, info = "NA values: Correct length")
 
-# Test 8: Test preserving existing result data
-# Setup
+## Test 8: Test preserving existing result data
+
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
 
@@ -180,18 +208,18 @@ summarized <- data.table(
 result <- list(existing_data = "should_be_preserved", other_field = 123)
 samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
 
-# Execute
+
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
 
-# Assert
+
 expect_equal(output$existing_data, "should_be_preserved", info = "Preserve existing: existing_data field")
 expect_equal(output$other_field, 123, info = "Preserve existing: other_field")
 expect_true("MissingPercentage" %in% names(output), info = "Preserve existing: MissingPercentage added")
 
-# Test 9: Test with complex contrast matrix (multiple comparisons)
+## Test 9: Test with complex contrast matrix (multiple comparisons)
 # Complex contrast matrix with multiple non-zero values
 
-# Setup - contrast involving multiple groups with different weights
+
 contrast_matrix <- matrix(c(1, 1, -2, 0.5, -0.5, 0), nrow = 2, ncol = 3)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
 
@@ -205,19 +233,19 @@ summarized <- data.table(
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(20, 15, 10))
 
-# Execute
+
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 
-# Assert
+
 expect_equal(length(output$MissingPercentage), 2)
 expect_equal(length(output$ImputationPercentage), 2)
 expect_true(all(output$MissingPercentage >= 0))
 expect_true(all(output$ImputationPercentage >= 0))
 
-# Test 10: Edge case with zero total measurements
+## Test 10: Edge case with zero total measurements
 # Handles zero total measurements edge case
 
-# Setup
+
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
 
@@ -231,10 +259,9 @@ summarized <- data.table(
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
 
-# Execute
+
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 
-# Assert - should handle division by potentially small numbers
 expect_true(is.numeric(output$MissingPercentage))
 expect_true(is.numeric(output$ImputationPercentage))
 expect_false(is.na(output$MissingPercentage[1]))

--- a/inst/tinytest/test_utils_groupcomparison.R
+++ b/inst/tinytest/test_utils_groupcomparison.R
@@ -5,14 +5,12 @@ library(data.table)
 contrast_matrix <- matrix(c(1, -1, 0, 
                             0, 1, -1), nrow = 2, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-
 summarized <- data.table(
     GROUP = c("Group1", "Group1", "Group2", "Group2", "Group3", "Group3"),
     TotalGroupMeasurements = c(100, 100, 100, 100, 100, 100),
     NumMeasuredFeature = c(50, 50, 50, 50, 50, 50),
     NumImputedFeature = c(0, 0, 0, 0, 0, 0)
 )
-
 result <- data.table(
     logFC = c(6.154384, 6.154384),
     SE = c(0.2917031, 0.2917031),
@@ -35,14 +33,12 @@ expect_true(all(names(output) %in% c(names(result), "MissingPercentage")), info 
 ## Test 2: With imputed values
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
-
 summarized <- data.table(
     GROUP = c("Group1", "Group2"),
     TotalGroupMeasurements = c(100, 100),
     NumMeasuredFeature = c(80, 70),
     NumImputedFeature = c(10, 20)
 )
-
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
@@ -52,10 +48,8 @@ expect_equal(output$MissingPercentage[1], expected_missing, info = "Imputed valu
 expect_equal(output$ImputationPercentage[1], expected_imputed, info = "Imputed values: Imputation percentage calculation")
 
 ## Test 3: With empty conditions (groups not in summarized data)
-
 contrast_matrix <- matrix(c(1, -1, 0), nrow = 1, ncol = 3)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-
 summarized <- data.table(
     GROUP = c("Group1"),
     TotalGroupMeasurements = c(100),
@@ -65,206 +59,82 @@ summarized <- data.table(
 
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
-
-
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
-
-
 expect_equal(length(output$MissingPercentage), 1, info = "Empty conditions: MissingPercentage length")
 expect_true(is.numeric(output$MissingPercentage), info = "Empty conditions: Numeric output")
 
 ## Test 4: Multiple contrasts with different missing patterns
-
 contrast_matrix <- matrix(c(1, -1, 0, 
                             0, 1, -1, 
                             1, 0, -1), nrow = 3, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group3", "Group2", "Group1")
-
 summarized <- data.table(
     GROUP = c("Group1", "Group2", "Group3"),
     TotalGroupMeasurements = c(100, 100, 100),
     NumMeasuredFeature = c(90, 80, 70),
     NumImputedFeature = c(5, 10, 15)
 )
-
 result <- list()
 samples_info <- data.table(
     GROUP = c("Group3", "Group2", "Group1"), 
     NumRuns = c(1, 1, 1)
 )
-
-# Execute
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 
-# Assert - Verify specific calculations for each contrast
-# Contrast 1: Group3 vs Group2 (1*Group3 + -1*Group2 + 0*Group1)
-# Groups involved: Group3 (70 measured, 100 total), Group2 (80 measured, 100 total)
 expected_missing_1 <- 1 - (70 + 80) / (100 + 100)  # 1 - 150/200 = 0.25
 expected_imputed_1 <- (15 + 10) / (100 + 100)      # 25/200 = 0.125
-
-# Contrast 2: Group2 vs Group1 (0*Group3 + 1*Group2 + -1*Group1)  
-# Groups involved: Group2 (80 measured, 100 total), Group1 (90 measured, 100 total)
 expected_missing_2 <- 1 - (80 + 90) / (100 + 100)  # 1 - 170/200 = 0.15
 expected_imputed_2 <- (10 + 5) / (100 + 100)       # 15/200 = 0.075
-
-# Contrast 3: Group3 vs Group1 (1*Group3 + 0*Group2 + -1*Group1)
-# Groups involved: Group3 (70 measured, 100 total), Group1 (90 measured, 100 total)  
 expected_missing_3 <- 1 - (70 + 90) / (100 + 100)  # 1 - 160/200 = 0.20
 expected_imputed_3 <- (15 + 5) / (100 + 100)       # 20/200 = 0.10
 
 expect_equal(length(output$MissingPercentage), 3, info = "Column ordering: MissingPercentage length")
 expect_equal(length(output$ImputationPercentage), 3, info = "Column ordering: ImputationPercentage length")
-
-# Verify exact calculations regardless of column order
 expect_equal(output$MissingPercentage[1], expected_missing_1, info = "Column ordering: Contrast 1 missing percentage (Group3 vs Group2)")
 expect_equal(output$ImputationPercentage[1], expected_imputed_1, info = "Column ordering: Contrast 1 imputation percentage")
-
 expect_equal(output$MissingPercentage[2], expected_missing_2, info = "Column ordering: Contrast 2 missing percentage (Group2 vs Group1)")
 expect_equal(output$ImputationPercentage[2], expected_imputed_2, info = "Column ordering: Contrast 2 imputation percentage")
-
 expect_equal(output$MissingPercentage[3], expected_missing_3, info = "Column ordering: Contrast 3 missing percentage (Group3 vs Group1)")
 expect_equal(output$ImputationPercentage[3], expected_imputed_3, info = "Column ordering: Contrast 3 imputation percentage")
 
 ## Test 5: Edge case with all values missing in one group
-
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
-
 summarized <- data.table(
     GROUP = c("Group1", "Group2"),
-    TotalGroupMeasurements = c(100, 100),
-    NumMeasuredFeature = c(0, 100),
-    NumImputedFeature = c(0, 0)
+    TotalGroupMeasurements = c(0, 100),
+    NumMeasuredFeature = c(0, 80),
+    NumImputedFeature = c(0, 20)
 )
-
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
-
-
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
-
-
-expected_missing <- 1 - (0 + 100) / (100 + 100) # 0.5
+expected_missing <- 1 - (0 + 80) / (0 + 100) # 0.2
 expect_equal(output$MissingPercentage[1], expected_missing, info = "Complete missing group: Missing percentage calculation")
 
-## Test 6: Single group contrast
-
-contrast_matrix <- matrix(c(1, 0, 0), nrow = 1, ncol = 3)
+## Test 6: Test with complex contrast matrix (multiple comparisons)
+contrast_matrix <- matrix(c(0.5, 0.5, -1, 1, -1, 0), nrow = 2, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-
-summarized <- data.table(
-    GROUP = c("Group1", "Group2", "Group3"),
-    TotalGroupMeasurements = c(100, 100, 100),
-    NumMeasuredFeature = c(75, 80, 85),
-    NumImputedFeature = c(10, 5, 0)
-)
-
-result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
-
-
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
-
-
-expected_missing <- 1 - 75 / 100 # Only Group1 is involved
-expected_imputed <- 10 / 100
-
-expect_equal(output$MissingPercentage[1], expected_missing, info = "Single group contrast: Missing percentage")
-expect_equal(output$ImputationPercentage[1], expected_imputed, info = "Single group contrast: Imputation percentage")
-
-## Test 7: Test with NA values in summarized data
-
-contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
-colnames(contrast_matrix) <- c("Group1", "Group2")
-
-summarized <- data.table(
-    GROUP = c("Group1", "Group2"),
-    TotalGroupMeasurements = c(100, 100),
-    NumMeasuredFeature = c(NA, 80),
-    NumImputedFeature = c(0, NA)
-)
-
-result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
-
-
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
-
-
-expect_true(is.numeric(output$MissingPercentage), info = "NA values: Numeric MissingPercentage")
-expect_true(is.numeric(output$ImputationPercentage), info = "NA values: Numeric ImputationPercentage")
-expect_equal(length(output$MissingPercentage), 1, info = "NA values: Correct length")
-
-## Test 8: Test preserving existing result data
-
-contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
-colnames(contrast_matrix) <- c("Group1", "Group2")
-
-summarized <- data.table(
-    GROUP = c("Group1", "Group2"),
-    TotalGroupMeasurements = c(100, 100),
-    NumMeasuredFeature = c(90, 80),
-    NumImputedFeature = c(5, 10)
-)
-
-result <- list(existing_data = "should_be_preserved", other_field = 123)
-samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
-
-
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
-
-
-expect_equal(output$existing_data, "should_be_preserved", info = "Preserve existing: existing_data field")
-expect_equal(output$other_field, 123, info = "Preserve existing: other_field")
-expect_true("MissingPercentage" %in% names(output), info = "Preserve existing: MissingPercentage added")
-
-## Test 9: Test with complex contrast matrix (multiple comparisons)
-# Complex contrast matrix with multiple non-zero values
-
-
-contrast_matrix <- matrix(c(0.5, 0.5, -1, 0.5, -0.5, 0), nrow = 2, ncol = 3, byrow = TRUE)
-colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-
 summarized <- data.table(
     GROUP = c("Group1", "Group2", "Group3"),
     TotalGroupMeasurements = c(200, 150, 100),
     NumMeasuredFeature = c(180, 120, 80),
     NumImputedFeature = c(10, 15, 5)
 )
-
 result <- list()
 samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(20, 15, 10))
-
-
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
-
-
-expect_equal(length(output$MissingPercentage), 2)
-expect_equal(length(output$ImputationPercentage), 2)
-expect_true(all(output$MissingPercentage >= 0))
-expect_true(all(output$ImputationPercentage >= 0))
-
-## Test 10: Edge case with zero total measurements
-# Handles zero total measurements edge case
-
-
-contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
-colnames(contrast_matrix) <- c("Group1", "Group2")
-
-summarized <- data.table(
-    GROUP = c("Group1", "Group2"),
-    TotalGroupMeasurements = c(0, 100),
-    NumMeasuredFeature = c(0, 80),
-    NumImputedFeature = c(0, 10)
-)
-
-result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
-
-
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
-
-expect_true(is.numeric(output$MissingPercentage))
-expect_true(is.numeric(output$ImputationPercentage))
-expect_false(is.na(output$MissingPercentage[1]))
-
+expected_missing_1 <- 1 - 380 / 450  
+expected_imputed_1 <- 30 / 450       
+expected_missing_2 <- 1 - 300 / 350  # 1 - 0.8571 = 0.1429 (approximately)
+expected_imputed_2 <- 25 / 350       # 0.0714 (approximately)
+expect_equal(length(output$MissingPercentage), 2, info = "Complex contrast: MissingPercentage length")
+expect_equal(length(output$ImputationPercentage), 2, info = "Complex contrast: ImputationPercentage length")
+expect_equal(output$MissingPercentage[1], expected_missing_1, tolerance = 1e-10, 
+             info = "Complex contrast: Contrast 1 missing percentage (0.5*Group1 + 0.5*Group2 - Group3)")
+expect_equal(output$ImputationPercentage[1], expected_imputed_1, tolerance = 1e-10,
+             info = "Complex contrast: Contrast 1 imputation percentage")
+expect_equal(output$MissingPercentage[2], expected_missing_2, tolerance = 1e-10,
+             info = "Complex contrast: Contrast 2 missing percentage (Group1 - Group2)")  
+expect_equal(output$ImputationPercentage[2], expected_imputed_2, tolerance = 1e-10,
+             info = "Complex contrast: Contrast 2 imputation percentage")

--- a/inst/tinytest/test_utils_groupcomparison.R
+++ b/inst/tinytest/test_utils_groupcomparison.R
@@ -26,7 +26,10 @@ output <- MSstats:::.countMissingPercentage(
 expect_equal(length(output$MissingPercentage), 2, info = "Basic functionality: MissingPercentage length")
 expect_equal(output$MissingPercentage, c(0, 0), info = "Basic functionality: No missing values")
 expect_true(is.null(output$ImputationPercentage), info = "Basic functionality: No imputation when has_imputed = FALSE")
-expect_true(all(names(output) %in% c(names(result), "MissingPercentage")), info = "Basic functionality: Preserve existing result data")
+expect_true(all(names(result) %in% names(output)), 
+            info = "Basic functionality: Preserve existing result columns")
+expect_true(setequal(names(output), c(names(result), "MissingPercentage")), 
+            info = "Basic functionality: No extraneous columns added")
 
 ## Test 2: With imputed values
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)

--- a/inst/tinytest/test_utils_groupcomparison.R
+++ b/inst/tinytest/test_utils_groupcomparison.R
@@ -1,0 +1,241 @@
+library(data.table)
+
+# Test 1: Basic functionality with no missing values
+# Setup
+contrast_matrix <- matrix(c(1, -1, 0, 
+                            0, 1, -1), nrow = 2, ncol = 3)
+colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group1", "Group2", "Group2", "Group3", "Group3"),
+    TotalGroupMeasurements = c(100, 100, 100, 100, 100, 100),
+    NumMeasuredFeature = c(50, 50, 50, 50, 50, 50),
+    NumImputedFeature = c(0, 0, 0, 0, 0, 0)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
+
+# Assert
+expect_equal(length(output$MissingPercentage), 2, info = "Basic functionality: MissingPercentage length")
+expect_equal(output$MissingPercentage, c(0, 0), info = "Basic functionality: No missing values")
+expect_true(is.null(output$ImputationPercentage), info = "Basic functionality: No imputation when has_imputed = FALSE")
+
+# Test 2: With imputed values
+# Setup
+contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
+colnames(contrast_matrix) <- c("Group1", "Group2")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group2"),
+    TotalGroupMeasurements = c(100, 100),
+    NumMeasuredFeature = c(80, 70),
+    NumImputedFeature = c(10, 20)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+
+# Assert
+expected_missing <- 1 - (80 + 70) / (100 + 100) # 0.25
+expected_imputed <- (10 + 20) / (100 + 100) # 0.15
+
+expect_equal(output$MissingPercentage[1], expected_missing, info = "Imputed values: Missing percentage calculation")
+expect_equal(output$ImputationPercentage[1], expected_imputed, info = "Imputed values: Imputation percentage calculation")
+
+# Test 3: With empty conditions (groups not in summarized data)
+# Setup
+contrast_matrix <- matrix(c(1, -1, 0), nrow = 1, ncol = 3)
+colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
+
+summarized <- data.table(
+    GROUP = c("Group1"),
+    TotalGroupMeasurements = c(100),
+    NumMeasuredFeature = c(80),
+    NumImputedFeature = c(0)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
+
+# Assert
+expect_equal(length(output$MissingPercentage), 1, info = "Empty conditions: MissingPercentage length")
+expect_true(is.numeric(output$MissingPercentage), info = "Empty conditions: Numeric output")
+
+# Test 4: Multiple contrasts with different missing patterns
+# Setup
+contrast_matrix <- matrix(c(1, -1, 0, 0, 1, -1, 1, 0, -1), nrow = 3, ncol = 3)
+colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group2", "Group3"),
+    TotalGroupMeasurements = c(100, 100, 100),
+    NumMeasuredFeature = c(90, 80, 70),
+    NumImputedFeature = c(5, 10, 15)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+
+# Assert
+expect_equal(length(output$MissingPercentage), 3, info = "Multiple contrasts: MissingPercentage length")
+expect_equal(length(output$ImputationPercentage), 3, info = "Multiple contrasts: ImputationPercentage length")
+expect_true(all(output$MissingPercentage >= 0), info = "Multiple contrasts: MissingPercentage non-negative")
+expect_true(all(output$MissingPercentage <= 1), info = "Multiple contrasts: MissingPercentage <= 1")
+
+# Test 5: Edge case with all values missing in one group
+# Setup
+contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
+colnames(contrast_matrix) <- c("Group1", "Group2")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group2"),
+    TotalGroupMeasurements = c(100, 100),
+    NumMeasuredFeature = c(0, 100),
+    NumImputedFeature = c(0, 0)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
+
+# Assert
+expected_missing <- 1 - (0 + 100) / (100 + 100) # 0.5
+expect_equal(output$MissingPercentage[1], expected_missing, info = "Complete missing group: Missing percentage calculation")
+
+# Test 6: Single group contrast
+# Setup
+contrast_matrix <- matrix(c(1, 0, 0), nrow = 1, ncol = 3)
+colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group2", "Group3"),
+    TotalGroupMeasurements = c(100, 100, 100),
+    NumMeasuredFeature = c(75, 80, 85),
+    NumImputedFeature = c(10, 5, 0)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+
+# Assert
+expected_missing <- 1 - 75 / 100 # Only Group1 is involved
+expected_imputed <- 10 / 100
+
+expect_equal(output$MissingPercentage[1], expected_missing, info = "Single group contrast: Missing percentage")
+expect_equal(output$ImputationPercentage[1], expected_imputed, info = "Single group contrast: Imputation percentage")
+
+# Test 7: Test with NA values in summarized data
+# Setup
+contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
+colnames(contrast_matrix) <- c("Group1", "Group2")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group2"),
+    TotalGroupMeasurements = c(100, 100),
+    NumMeasuredFeature = c(NA, 80),
+    NumImputedFeature = c(0, NA)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+
+# Assert - should handle NA values with na.rm = TRUE
+expect_true(is.numeric(output$MissingPercentage), info = "NA values: Numeric MissingPercentage")
+expect_true(is.numeric(output$ImputationPercentage), info = "NA values: Numeric ImputationPercentage")
+expect_equal(length(output$MissingPercentage), 1, info = "NA values: Correct length")
+
+# Test 8: Test preserving existing result data
+# Setup
+contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
+colnames(contrast_matrix) <- c("Group1", "Group2")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group2"),
+    TotalGroupMeasurements = c(100, 100),
+    NumMeasuredFeature = c(90, 80),
+    NumImputedFeature = c(5, 10)
+)
+
+result <- list(existing_data = "should_be_preserved", other_field = 123)
+samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
+
+# Assert
+expect_equal(output$existing_data, "should_be_preserved", info = "Preserve existing: existing_data field")
+expect_equal(output$other_field, 123, info = "Preserve existing: other_field")
+expect_true("MissingPercentage" %in% names(output), info = "Preserve existing: MissingPercentage added")
+
+# Test 9: Test with complex contrast matrix (multiple comparisons)
+# Complex contrast matrix with multiple non-zero values
+
+# Setup - contrast involving multiple groups with different weights
+contrast_matrix <- matrix(c(1, 1, -2, 0.5, -0.5, 0), nrow = 2, ncol = 3)
+colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group2", "Group3"),
+    TotalGroupMeasurements = c(200, 150, 100),
+    NumMeasuredFeature = c(180, 120, 80),
+    NumImputedFeature = c(10, 15, 5)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(20, 15, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+
+# Assert
+expect_equal(length(output$MissingPercentage), 2)
+expect_equal(length(output$ImputationPercentage), 2)
+expect_true(all(output$MissingPercentage >= 0))
+expect_true(all(output$ImputationPercentage >= 0))
+
+# Test 10: Edge case with zero total measurements
+# Handles zero total measurements edge case
+
+# Setup
+contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
+colnames(contrast_matrix) <- c("Group1", "Group2")
+
+summarized <- data.table(
+    GROUP = c("Group1", "Group2"),
+    TotalGroupMeasurements = c(0, 100),
+    NumMeasuredFeature = c(0, 80),
+    NumImputedFeature = c(0, 10)
+)
+
+result <- list()
+samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+
+# Execute
+output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+
+# Assert - should handle division by potentially small numbers
+expect_true(is.numeric(output$MissingPercentage))
+expect_true(is.numeric(output$ImputationPercentage))
+expect_false(is.na(output$MissingPercentage[1]))
+

--- a/inst/tinytest/test_utils_groupcomparison.R
+++ b/inst/tinytest/test_utils_groupcomparison.R
@@ -1,17 +1,15 @@
-library(data.table)
-
 # Test suite for .countMissingPercentage function
 ## Test 1: Basic functionality with no missing values
 contrast_matrix <- matrix(c(1, -1, 0, 
                             0, 1, -1), nrow = 2, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-summarized <- data.table(
+summarized <- data.table::data.table(
     GROUP = c("Group1", "Group1", "Group2", "Group2", "Group3", "Group3"),
     TotalGroupMeasurements = c(100, 100, 100, 100, 100, 100),
     NumMeasuredFeature = c(50, 50, 50, 50, 50, 50),
     NumImputedFeature = c(0, 0, 0, 0, 0, 0)
 )
-result <- data.table(
+result <- data.table::data.table(
     logFC = c(6.154384, 6.154384),
     SE = c(0.2917031, 0.2917031),
     Tvalue = c(21.09811, 21.09811),
@@ -21,7 +19,7 @@ result <- data.table(
     Label = c("Group1 - Group2", "Group2 - Group3"),
     issue = c(NA, NA)
 )
-samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(2, 2, 2))
+samples_info <- data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(2, 2, 2))
 output <- MSstats:::.countMissingPercentage(
     contrast_matrix, summarized, result, samples_info, FALSE
 )
@@ -33,14 +31,14 @@ expect_true(all(names(output) %in% c(names(result), "MissingPercentage")), info 
 ## Test 2: With imputed values
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
-summarized <- data.table(
+summarized <- data.table::data.table(
     GROUP = c("Group1", "Group2"),
     TotalGroupMeasurements = c(100, 100),
     NumMeasuredFeature = c(80, 70),
     NumImputedFeature = c(10, 20)
 )
 result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+samples_info <- data.table::data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 expected_missing <- 1 - (80 + 70) / (100 + 100) # 0.25
 expected_imputed <- (10 + 20) / (100 + 100) # 0.15
@@ -50,7 +48,7 @@ expect_equal(output$ImputationPercentage[1], expected_imputed, info = "Imputed v
 ## Test 3: With empty conditions (groups not in summarized data)
 contrast_matrix <- matrix(c(1, -1, 0), nrow = 1, ncol = 3)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-summarized <- data.table(
+summarized <- data.table::data.table(
     GROUP = c("Group1"),
     TotalGroupMeasurements = c(100),
     NumMeasuredFeature = c(80),
@@ -58,7 +56,7 @@ summarized <- data.table(
 )
 
 result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
+samples_info <- data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
 expect_equal(length(output$MissingPercentage), 1, info = "Empty conditions: MissingPercentage length")
 expect_true(is.numeric(output$MissingPercentage), info = "Empty conditions: Numeric output")
@@ -68,14 +66,14 @@ contrast_matrix <- matrix(c(1, -1, 0,
                             0, 1, -1, 
                             1, 0, -1), nrow = 3, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group3", "Group2", "Group1")
-summarized <- data.table(
+summarized <- data.table::data.table(
     GROUP = c("Group1", "Group2", "Group3"),
     TotalGroupMeasurements = c(100, 100, 100),
     NumMeasuredFeature = c(90, 80, 70),
     NumImputedFeature = c(5, 10, 15)
 )
 result <- list()
-samples_info <- data.table(
+samples_info <- data.table::data.table(
     GROUP = c("Group3", "Group2", "Group1"), 
     NumRuns = c(1, 1, 1)
 )
@@ -100,14 +98,14 @@ expect_equal(output$ImputationPercentage[3], expected_imputed_3, info = "Column 
 ## Test 5: Edge case with all values missing in one group
 contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
 colnames(contrast_matrix) <- c("Group1", "Group2")
-summarized <- data.table(
+summarized <- data.table::data.table(
     GROUP = c("Group1", "Group2"),
     TotalGroupMeasurements = c(0, 100),
     NumMeasuredFeature = c(0, 80),
     NumImputedFeature = c(0, 20)
 )
 result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+samples_info <- data.table::data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
 expected_missing <- 1 - (0 + 80) / (0 + 100) # 0.2
 expect_equal(output$MissingPercentage[1], expected_missing, info = "Complete missing group: Missing percentage calculation")
@@ -115,14 +113,14 @@ expect_equal(output$MissingPercentage[1], expected_missing, info = "Complete mis
 ## Test 6: Test with complex contrast matrix (multiple comparisons)
 contrast_matrix <- matrix(c(0.5, 0.5, -1, 1, -1, 0), nrow = 2, ncol = 3, byrow = TRUE)
 colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-summarized <- data.table(
+summarized <- data.table::data.table(
     GROUP = c("Group1", "Group2", "Group3"),
     TotalGroupMeasurements = c(200, 150, 100),
     NumMeasuredFeature = c(180, 120, 80),
     NumImputedFeature = c(10, 15, 5)
 )
 result <- list()
-samples_info <- data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(20, 15, 10))
+samples_info <- data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(20, 15, 10))
 output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 expected_missing_1 <- 1 - 380 / 450  
 expected_imputed_1 <- 30 / 450       


### PR DESCRIPTION
### **User description**
# Motivation and Context

MSstats was reporting the incorrect missing and imputation percentages for custom contrast matrices, specifically in the case where the contrast matrix column names did not match the order of the groups of the input data.  https://groups.google.com/g/msstats/c/mDzL88fJG34

## Testing

Added unit tests for .countMissingPercentage

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files


___

### **PR Type**
Bug fix


___

### **Description**
Fix missing percentage calculation order mismatch
Align `counts` with `contrast_matrix` columns
Prevent misaligned GROUP aggregations
Supports custom contrast matrices


___

### Diagram Walkthrough


```mermaid
flowchart LR
  summarized["Summarized data by GROUP"] -- aggregate --> counts["counts (totals, measured, imputed)"]
  contrast["contrast_matrix colnames"] -- match order --> aligned["counts aligned to contrast columns"]
  aligned -- used by --> missingPct[".countMissingPercentage computation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_groupcomparison.R</strong><dd><code>Align counts to contrast matrix column order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_groupcomparison.R

<ul><li>After GROUP-wise aggregation, reorders <code>counts</code> rows.<br> <li> Matches <code>counts</code> to <code>colnames(contrast_matrix)</code> via <code>match</code>.<br> <li> Ensures alignment for custom contrast matrices.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/171/files#diff-c5d36063f1c31fc4ab10e25cc5155ea5cfc7209b1b4f03d78f3992a6f268a41f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reordered group counts to align with specified contrast groups so summary statistics and empty-condition handling are consistent when some conditions have zero samples.

* **Tests**
  * Added 6 unit tests validating missing/imputation percentage calculations across typical and edge cases (NA, zero totals, single/multiple contrasts) and ensuring existing result fields are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->