### PR TITLE
style(countMissingPercentage): Fix styling of arrows to equal signs

### DIFF
--- a/R/utils_groupcomparison.R
+++ b/R/utils_groupcomparison.R
@@ -406,7 +406,7 @@ getSamplesInfo = function(summarization_output) {
                                  NumImputedFeature = sum(NumImputedFeature, 
                                                          na.rm = TRUE)),
                             by = "GROUP"]
-        counts <- counts[match(intersect(colnames(contrast_matrix), GROUP), GROUP), ]
+        counts = counts[match(intersect(colnames(contrast_matrix), GROUP), GROUP), ]
     
     empty_conditions = setdiff(samples_info$GROUP, unique(counts$GROUP))
     if (length(empty_conditions) !=0) {

--- a/inst/tinytest/test_utils_groupcomparison.R
+++ b/inst/tinytest/test_utils_groupcomparison.R
@@ -1,15 +1,15 @@
 # Test suite for .countMissingPercentage function
 ## Test 1: Basic functionality with no missing values
-contrast_matrix <- matrix(c(1, -1, 0, 
+contrast_matrix = matrix(c(1, -1, 0, 
                             0, 1, -1), nrow = 2, ncol = 3, byrow = TRUE)
-colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-summarized <- data.table::data.table(
+colnames(contrast_matrix) = c("Group1", "Group2", "Group3")
+summarized = data.table::data.table(
     GROUP = c("Group1", "Group1", "Group2", "Group2", "Group3", "Group3"),
     TotalGroupMeasurements = c(100, 100, 100, 100, 100, 100),
     NumMeasuredFeature = c(50, 50, 50, 50, 50, 50),
     NumImputedFeature = c(0, 0, 0, 0, 0, 0)
 )
-result <- data.table::data.table(
+result = data.table::data.table(
     logFC = c(6.154384, 6.154384),
     SE = c(0.2917031, 0.2917031),
     Tvalue = c(21.09811, 21.09811),
@@ -19,8 +19,8 @@ result <- data.table::data.table(
     Label = c("Group1 - Group2", "Group2 - Group3"),
     issue = c(NA, NA)
 )
-samples_info <- data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(2, 2, 2))
-output <- MSstats:::.countMissingPercentage(
+samples_info = data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(2, 2, 2))
+output = MSstats:::.countMissingPercentage(
     contrast_matrix, summarized, result, samples_info, FALSE
 )
 expect_equal(length(output$MissingPercentage), 2, info = "Basic functionality: MissingPercentage length")
@@ -32,62 +32,62 @@ expect_true(setequal(names(output), c(names(result), "MissingPercentage")),
             info = "Basic functionality: No extraneous columns added")
 
 ## Test 2: With imputed values
-contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
-colnames(contrast_matrix) <- c("Group1", "Group2")
-summarized <- data.table::data.table(
+contrast_matrix = matrix(c(1, -1), nrow = 1, ncol = 2)
+colnames(contrast_matrix) = c("Group1", "Group2")
+summarized = data.table::data.table(
     GROUP = c("Group1", "Group2"),
     TotalGroupMeasurements = c(100, 100),
     NumMeasuredFeature = c(80, 70),
     NumImputedFeature = c(10, 20)
 )
-result <- list()
-samples_info <- data.table::data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
-expected_missing <- 1 - (80 + 70) / (100 + 100) # 0.25
-expected_imputed <- (10 + 20) / (100 + 100) # 0.15
+result = list()
+samples_info = data.table::data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+output = MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+expected_missing = 1 - (80 + 70) / (100 + 100) # 0.25
+expected_imputed = (10 + 20) / (100 + 100) # 0.15
 expect_equal(output$MissingPercentage[1], expected_missing, info = "Imputed values: Missing percentage calculation")
 expect_equal(output$ImputationPercentage[1], expected_imputed, info = "Imputed values: Imputation percentage calculation")
 
 ## Test 3: With empty conditions (groups not in summarized data)
-contrast_matrix <- matrix(c(1, -1, 0), nrow = 1, ncol = 3)
-colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-summarized <- data.table::data.table(
+contrast_matrix = matrix(c(1, -1, 0), nrow = 1, ncol = 3)
+colnames(contrast_matrix) = c("Group1", "Group2", "Group3")
+summarized = data.table::data.table(
     GROUP = c("Group1"),
     TotalGroupMeasurements = c(100),
     NumMeasuredFeature = c(80),
     NumImputedFeature = c(0)
 )
 
-result <- list()
-samples_info <- data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
+result = list()
+samples_info = data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(10, 10, 10))
+output = MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
 expect_equal(length(output$MissingPercentage), 1, info = "Empty conditions: MissingPercentage length")
 expect_true(is.numeric(output$MissingPercentage), info = "Empty conditions: Numeric output")
 
 ## Test 4: Multiple contrasts with different missing patterns
-contrast_matrix <- matrix(c(1, -1, 0, 
+contrast_matrix = matrix(c(1, -1, 0, 
                             0, 1, -1, 
                             1, 0, -1), nrow = 3, ncol = 3, byrow = TRUE)
-colnames(contrast_matrix) <- c("Group3", "Group2", "Group1")
-summarized <- data.table::data.table(
+colnames(contrast_matrix) = c("Group3", "Group2", "Group1")
+summarized = data.table::data.table(
     GROUP = c("Group1", "Group2", "Group3"),
     TotalGroupMeasurements = c(100, 100, 100),
     NumMeasuredFeature = c(90, 80, 70),
     NumImputedFeature = c(5, 10, 15)
 )
-result <- list()
-samples_info <- data.table::data.table(
+result = list()
+samples_info = data.table::data.table(
     GROUP = c("Group3", "Group2", "Group1"), 
     NumRuns = c(1, 1, 1)
 )
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+output = MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
 
-expected_missing_1 <- 1 - (70 + 80) / (100 + 100)  # 1 - 150/200 = 0.25
-expected_imputed_1 <- (15 + 10) / (100 + 100)      # 25/200 = 0.125
-expected_missing_2 <- 1 - (80 + 90) / (100 + 100)  # 1 - 170/200 = 0.15
-expected_imputed_2 <- (10 + 5) / (100 + 100)       # 15/200 = 0.075
-expected_missing_3 <- 1 - (70 + 90) / (100 + 100)  # 1 - 160/200 = 0.20
-expected_imputed_3 <- (15 + 5) / (100 + 100)       # 20/200 = 0.10
+expected_missing_1 = 1 - (70 + 80) / (100 + 100)  # 1 - 150/200 = 0.25
+expected_imputed_1 = (15 + 10) / (100 + 100)      # 25/200 = 0.125
+expected_missing_2 = 1 - (80 + 90) / (100 + 100)  # 1 - 170/200 = 0.15
+expected_imputed_2 = (10 + 5) / (100 + 100)       # 15/200 = 0.075
+expected_missing_3 = 1 - (70 + 90) / (100 + 100)  # 1 - 160/200 = 0.20
+expected_imputed_3 = (15 + 5) / (100 + 100)       # 20/200 = 0.10
 
 expect_equal(length(output$MissingPercentage), 3, info = "Column ordering: MissingPercentage length")
 expect_equal(length(output$ImputationPercentage), 3, info = "Column ordering: ImputationPercentage length")
@@ -99,36 +99,36 @@ expect_equal(output$MissingPercentage[3], expected_missing_3, info = "Column ord
 expect_equal(output$ImputationPercentage[3], expected_imputed_3, info = "Column ordering: Contrast 3 imputation percentage")
 
 ## Test 5: Edge case with all values missing in one group
-contrast_matrix <- matrix(c(1, -1), nrow = 1, ncol = 2)
-colnames(contrast_matrix) <- c("Group1", "Group2")
-summarized <- data.table::data.table(
+contrast_matrix = matrix(c(1, -1), nrow = 1, ncol = 2)
+colnames(contrast_matrix) = c("Group1", "Group2")
+summarized = data.table::data.table(
     GROUP = c("Group1", "Group2"),
     TotalGroupMeasurements = c(0, 100),
     NumMeasuredFeature = c(0, 80),
     NumImputedFeature = c(0, 20)
 )
-result <- list()
-samples_info <- data.table::data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
-expected_missing <- 1 - (0 + 80) / (0 + 100) # 0.2
+result = list()
+samples_info = data.table::data.table(GROUP = c("Group1", "Group2"), NumRuns = c(10, 10))
+output = MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, FALSE)
+expected_missing = 1 - (0 + 80) / (0 + 100) # 0.2
 expect_equal(output$MissingPercentage[1], expected_missing, info = "Complete missing group: Missing percentage calculation")
 
 ## Test 6: Test with complex contrast matrix (multiple comparisons)
-contrast_matrix <- matrix(c(0.5, 0.5, -1, 1, -1, 0), nrow = 2, ncol = 3, byrow = TRUE)
-colnames(contrast_matrix) <- c("Group1", "Group2", "Group3")
-summarized <- data.table::data.table(
+contrast_matrix = matrix(c(0.5, 0.5, -1, 1, -1, 0), nrow = 2, ncol = 3, byrow = TRUE)
+colnames(contrast_matrix) = c("Group1", "Group2", "Group3")
+summarized = data.table::data.table(
     GROUP = c("Group1", "Group2", "Group3"),
     TotalGroupMeasurements = c(200, 150, 100),
     NumMeasuredFeature = c(180, 120, 80),
     NumImputedFeature = c(10, 15, 5)
 )
-result <- list()
-samples_info <- data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(20, 15, 10))
-output <- MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
-expected_missing_1 <- 1 - 380 / 450  
-expected_imputed_1 <- 30 / 450       
-expected_missing_2 <- 1 - 300 / 350  # 1 - 0.8571 = 0.1429 (approximately)
-expected_imputed_2 <- 25 / 350       # 0.0714 (approximately)
+result = list()
+samples_info = data.table::data.table(GROUP = c("Group1", "Group2", "Group3"), NumRuns = c(20, 15, 10))
+output = MSstats:::.countMissingPercentage(contrast_matrix, summarized, result, samples_info, TRUE)
+expected_missing_1 = 1 - 380 / 450  
+expected_imputed_1 = 30 / 450       
+expected_missing_2 = 1 - 300 / 350  # 1 - 0.8571 = 0.1429 (approximately)
+expected_imputed_2 = 25 / 350       # 0.0714 (approximately)
 expect_equal(length(output$MissingPercentage), 2, info = "Complex contrast: MissingPercentage length")
 expect_equal(length(output$ImputationPercentage), 2, info = "Complex contrast: ImputationPercentage length")
 expect_equal(output$MissingPercentage[1], expected_missing_1, tolerance = 1e-10, 


### PR DESCRIPTION
### **User description**
# Motivation and Context

Accidentally used arrows instead of equal signs in https://github.com/Vitek-Lab/MSstats/pull/171

## Changes

- Fix styling from arrows to equal signs. 

## Testing

Existing unit tests pass

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Standardize assignment operators to '='

- Align function usage across code, tests

- Minor refactor in counts indexing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  utils["R/utils_groupcomparison.R getSamplesInfo()"] -- "style: <- to =" --> utils
  tests["inst/tinytest/test_utils_groupcomparison.R"] -- "style: <- to =" --> tests
  utils -- "consistent API expectations" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_groupcomparison.R</strong><dd><code>Use '=' for counts reassignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_groupcomparison.R

<ul><li>Replace '<-' with '=' for assignment<br> <li> Keep logic and data.table operations unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/172/files#diff-c5d36063f1c31fc4ab10e25cc5155ea5cfc7209b1b4f03d78f3992a6f268a41f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_utils_groupcomparison.R</strong><dd><code>Tests updated to '=' assignment style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inst/tinytest/test_utils_groupcomparison.R

<ul><li>Replace '<-' with '=' throughout tests<br> <li> Preserve all test logic and expectations</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/172/files#diff-1bce7792602732c7652890a73bbe5c038463e847c7e2386a8aa8d21bbcbe346f">+49/-49</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized assignment operator usage for consistency; no behavioral changes.
- Tests
  - Updated test code to use consistent assignment syntax; test logic and outcomes unchanged.
- Notes
  - No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->