### PR TITLE
feat(dataProcessPlots): Add confidence interval bars to profile plots

### DIFF
--- a/R/dataProcessPlots.R
+++ b/R/dataProcessPlots.R
@@ -386,10 +386,10 @@ dataProcessPlots = function(
              TRANSITION = "Run summary", FEATURE = "Run summary",
              LABEL = "Endogenous", RUN = RUN,
              ABUNDANCE = LogIntensities, FRACTION = 1, 
-             UPPERBOUND = if("Variance" %in% names(.SD)) LogIntensities + 1.96 * sqrt(Variance) else NA_real_,
+             UPPERBOUND = if("Variance" %in% names(.SD)) LogIntensities + 1.96 * sqrt(Variance) else NA_real_, # 95% confidence interval
              LOWERBOUND = if("Variance" %in% names(.SD)) LogIntensities - 1.96 * sqrt(Variance) else NA_real_
-             )
-        ]
+        )
+      ]
       if (is_censored) {
         quant$censored = FALSE
       }

--- a/R/dataProcessPlots.R
+++ b/R/dataProcessPlots.R
@@ -385,7 +385,10 @@ dataProcessPlots = function(
         list(PROTEIN = unique(Protein), PEPTIDE = "Run summary",
              TRANSITION = "Run summary", FEATURE = "Run summary",
              LABEL = "Endogenous", RUN = RUN,
-             ABUNDANCE = LogIntensities, FRACTION = 1)
+             ABUNDANCE = LogIntensities, FRACTION = 1, 
+             UPPERBOUND = if("Variance" %in% names(.SD)) LogIntensities + 1.96 * sqrt(Variance) else NA_real_,
+             LOWERBOUND = if("Variance" %in% names(.SD)) LogIntensities - 1.96 * sqrt(Variance) else NA_real_
+             )
         ]
       if (is_censored) {
         quant$censored = FALSE

--- a/R/utils_dataprocess_plots.R
+++ b/R/utils_dataprocess_plots.R
@@ -177,7 +177,7 @@
                               ymin = .data$LOWERBOUND, 
                               ymax = .data$UPPERBOUND,
                               color = .data$analysis),
-                          width = 0.3, # Probably needs to be adjustable for user
+                          width = 0.3,
                           linewidth = 0.5,
                           linetype = "solid") + 
             scale_shape_manual(values = c(16, 1), 

--- a/R/utils_dataprocess_plots.R
+++ b/R/utils_dataprocess_plots.R
@@ -172,6 +172,14 @@
                        aes(x = .data$RUN, y = .data$newABUNDANCE, 
                                   color = .data$analysis, size = .data$analysis, 
                                   shape = .data$censored)) +
+            geom_errorbar(data = input[input$PEPTIDE == "Run summary"],
+                          aes(x = .data$RUN, 
+                              ymin = .data$LOWERBOUND, 
+                              ymax = .data$UPPERBOUND,
+                              color = .data$analysis),
+                          width = 0.3, # Probably needs to be adjustable for user
+                          linewidth = 0.5,
+                          linetype = "solid") + 
             scale_shape_manual(values = c(16, 1), 
                                labels = c("Detected data",
                                           "Censored missing data"))

--- a/vignettes/MSstatsPlus.Rmd
+++ b/vignettes/MSstatsPlus.Rmd
@@ -297,6 +297,12 @@ will be included called `Variance` indicating the variance of the underlying
 protein abundance estimate. This variance is used in the next step of the
 workflow.
 
+Meanwhile, one can generate a profile plot to visualize the variance of the underlying protein abundance estimates in the form of 95% confidence intervals. For example, with Q9UFW8, one may observe that confidence intervals are wider for runs with more imputed values.
+
+```{r}
+dataProcessPlots(summarized, "ProfilePlot", which.Protein = "Q9UFW8", address = FALSE)
+```
+
 ## Differential analysis
 
 The final step of the `MSstats+` workflow is to perform differential analysis. 


### PR DESCRIPTION
# Motivation and Context

We should add confidence intervals for MSstats+

## Changes

- If the variance column exists in the quantitative output of `dataProcess`, then add confidence interval bars to profile plot

## Testing

- Verified confidence intervals were added when variance column exists, and none otherwise.
- Tested with MSstats+ vignette.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile plots now show 95% confidence-like intervals as error bars on peptide run summary plots when variance is available, highlighting uncertainty around intensity measurements.

* **Documentation**
  * Vignette updated with a paragraph and example demonstrating the new profile-plot visualization and how to call it for summarized data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->