### PR TITLE
fix(linear-summarization): Remove interaction term check to enable features with colons

### DIFF
--- a/src/linear_summary.cpp
+++ b/src/linear_summary.cpp
@@ -27,10 +27,9 @@ NumericVector get_intercept(CharacterVector coef_names) {
 } 
 
 NumericVector get_features(CharacterVector coef_names, NumericVector find_features,
-                           NumericVector find_colon, NumericVector contrast_matrix,
+                           NumericVector contrast_matrix,
                            NumericMatrix counts, DataFrame input) {
-    NumericVector just_features = setdiff(find_features, find_colon);
-    CharacterVector temp_feature = coef_names[just_features];
+    CharacterVector temp_feature = coef_names[find_features];
     
     NumericVector feature(0);
     if (temp_feature.length() != 0) {
@@ -41,12 +40,11 @@ NumericVector get_features(CharacterVector coef_names, NumericVector find_featur
 } 
 
 NumericVector get_run(CharacterVector coef_names,
-                      NumericVector find_runs, NumericVector find_colon,
+                      NumericVector find_runs,
                       NumericVector contrast_matrix, bool label, int n_runs) {
-    NumericVector just_runs = setdiff(find_runs, find_colon);
     NumericVector run(0);
-    if (just_runs.length() != 0) {
-        CharacterVector temp_run = coef_names[just_runs];
+    if (find_runs.length() != 0) {
+        CharacterVector temp_run = coef_names[find_runs];
         if (label) {
             run = rep(1 / n_runs, temp_run.length());
         } else {
@@ -138,14 +136,13 @@ NumericVector make_contrast_run_quant(DataFrame input,
     
     CharacterVector coef_names = coefs.attr("names");
     NumericVector find_features = grep("FEATURE", coef_names);
-    NumericVector find_colon = grep(":", coef_names);
     NumericVector find_runs = grep("RUN", coef_names);
     NumericVector find_ref = grep("ref", coef_names);
 
     NumericVector intercept = get_intercept(coef_names);
-    NumericVector features = get_features(coef_names, find_features, find_colon,
+    NumericVector features = get_features(coef_names, find_features,
                                           contrast_matrix, counts, input);
-    NumericVector runs = get_run(coef_names, find_runs, find_colon, 
+    NumericVector runs = get_run(coef_names, find_runs,
                                  contrast_matrix, is_labeled, n_runs);
     NumericVector refs = get_ref(coef_names, find_ref, contrast_matrix, input,
                                  is_reference);


### PR DESCRIPTION
# Motivation and Context

There looked to be problems w.r.t. features containing colons in them.  Notably, here:

```
NumericVector find_colon = grep(":", coef_names);
NumericVector just_runs = setdiff(find_runs, find_colon);
NumericVector just_features = setdiff(find_features, find_colon);
```

I believe this was written to find interaction terms (e.g., RUN:FEATURE), and then setdiff/intersect against find_runs and find_features is used to distinguish "just runs", "just features", and "run:feature interactions".

But if a Run ID or Feature ID contains a colon (like UniMod:7), those indices end up in find_colon, and then get incorrectly excluded from just_features or just_runs via setdiff. So legitimate main-effect terms get treated as if they were interaction terms and dropped.

Looking at the model formulas, there are no interaction terms anywhere in this code. All models use only main effects, so the simplest fix is to just remove find_colon entirely and clean up the functions that use it:

## Changes

Please provide a detailed bullet point list of your changes.

- Remove all references to finding indices to colons in the linear summarization function.

## Testing

- Verified datasets with features containing only colons were processed properly

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run the devtools::document() command after my changes and committed the added files