### PR TITLE
Fix weights for sample size calculation

### DIFF
--- a/R/utils_groupcomparison.R
+++ b/R/utils_groupcomparison.R
@@ -140,8 +140,8 @@ getSamplesInfo = function(summarization_output) {
                                        is_single_subject, has_tech_replicates) {
     
     if ("Variance" %in% colnames(input) & !all(is.na(input$Variance))){
-        weight_input = 1/input$Variance
-        weight_input = weight_input / mean(weight_input) # normalize weights
+        unnormalized_weight_input = 1/input$Variance
+        weight_input = unnormalized_weight_input / mean(unnormalized_weight_input)
     } else {
         weight_input = NULL
     }

--- a/R/utils_groupcomparison.R
+++ b/R/utils_groupcomparison.R
@@ -141,6 +141,7 @@ getSamplesInfo = function(summarization_output) {
     
     if ("Variance" %in% colnames(input) & !all(is.na(input$Variance))){
         weight_input = 1/input$Variance
+        weight_input = weight_input / mean(weight_input) # normalize weights
     } else {
         weight_input = NULL
     }


### PR DESCRIPTION
TBD to Merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

In group comparison models, when observations have associated variance estimates, inverse-variance weighting can be applied to give more weight to observations with lower variance (higher precision). Previously, weights were passed directly as inverse-variance values, which could inadvertently affect the scale of variance components. This PR normalizes the weights to sum to the sample size so that sample size calculation between MSstats and MSstats+ are comparable.  

## Solution

The weighting logic in `.fitModelForGroupComparison` has been updated to normalize inverse-variance weights. When a Variance column is present and contains non-NA values, the weights are now computed as: `weight_input = (1/Variance) / mean(1/Variance)`, ensuring weights sum to the sample size

## Detailed Changes

- **R/utils_groupcomparison.R** (lines 142-147):
  - Modified weight calculation logic in `.fitModelForGroupComparison` function
  - Changed from passing weights as-is to computing normalized inverse-variance weights internally
  - Introduced intermediate variable `unnormalized_weight_input = 1/input$Variance` for clarity
  - Applied normalization: `weight_input = unnormalized_weight_input / mean(unnormalized_weight_input)`
  - Preserves existing behavior for cases without variance information (weight_input = NULL)

## Unit Tests

- **inst/tinytest/test_utils_groupComparison_model.R**:
  - Test verifies that weights are applied to the fitted model when Variance column is provided
  - Currently expects unnormalized weights `1/Variance`, requiring update to verify normalized weights calculation

## Coding Guidelines Violations

The existing test in `test_utils_groupComparison_model.R` (lines 16-17) does not account for the weight normalization introduced in this PR. The test assertion `expect_equal(result$full_fit$weights, expected_weights)` where `expected_weights = 1/test_input_with_variance$Variance` will fail because the actual weights are normalized by their mean. The test should be updated to check for `expected_weights / mean(expected_weights)` to properly validate the normalized weighting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->