### PR TITLE
fix(checks): support 'heavy'/'light' IsotopeLabelType explicitly

### DIFF
--- a/R/utils_checks.R
+++ b/R/utils_checks.R
@@ -146,14 +146,16 @@ MSstatsPrepareForDataProcess = function(input, log_base, fix_missing) {
 #' @param x character or factor vector of IsotopeLabelType values
 #' @return factor with levels from \code{c("H","L")} restricted to those present
 #' @keywords internal
+#' @noRd
 .mapIsotopeLabelType = function(x) {
     label_map <- c(
-        "H"     = "H",
-        "L"     = "L",
+        "h"     = "H",
+        "l"     = "L",
         "heavy" = "H",
         "light" = "L"
     )
-    mapped <- label_map[as.character(x)]
+    key <- tolower(trimws(as.character(x)))
+    mapped <- unname(label_map[key])
     factor(mapped, levels = intersect(c("H", "L"), mapped))
 }
 

--- a/R/utils_checks.R
+++ b/R/utils_checks.R
@@ -142,6 +142,22 @@ MSstatsPrepareForDataProcess = function(input, log_base, fix_missing) {
 }
 
 
+#' Map IsotopeLabelType values to canonical "H"/"L" levels
+#' @param x character or factor vector of IsotopeLabelType values
+#' @return factor with levels from \code{c("H","L")} restricted to those present
+#' @keywords internal
+.mapIsotopeLabelType = function(x) {
+    label_map <- c(
+        "H"     = "H",
+        "L"     = "L",
+        "heavy" = "H",
+        "light" = "L"
+    )
+    mapped <- label_map[as.character(x)]
+    factor(mapped, levels = intersect(c("H", "L"), mapped))
+}
+
+
 #' Check validity of data that were not processed by MSstats converter
 #' @param input data.table
 #' @inheritParams MSstatsPrepareForDataProcess
@@ -208,12 +224,7 @@ MSstatsPrepareForDataProcess = function(input, log_base, fix_missing) {
         stop("Statistical tools in MSstats are only proper for label-free or with reference peptide experiments.")
     }
     
-    input$ISOTOPELABELTYPE = factor(input$ISOTOPELABELTYPE)
-    if (data.table::uniqueN(input$ISOTOPELABELTYPE) == 2) {
-        levels(input$ISOTOPELABELTYPE) = c("H", "L")
-    } else {
-        levels(input$ISOTOPELABELTYPE) = "L"
-    }
+    input$ISOTOPELABELTYPE <- .mapIsotopeLabelType(input$ISOTOPELABELTYPE)
     input
 }
 
@@ -231,16 +242,7 @@ MSstatsPrepareForDataProcess = function(input, log_base, fix_missing) {
     }
     input$PEPTIDE = paste(input$PEPTIDESEQUENCE, input$PRECURSORCHARGE, sep = "_")
     input$TRANSITION = paste(input$FRAGMENTION, input$PRODUCTCHARGE, sep = "_")
-    label_map <- c(
-        "H"     = "H",
-        "L"     = "L",
-        "heavy" = "H",
-        "light" = "L"
-    )
-    input$ISOTOPELABELTYPE <- factor(
-        label_map[as.character(input$ISOTOPELABELTYPE)],
-        levels = intersect(c("H", "L"), label_map[as.character(input$ISOTOPELABELTYPE)])
-    )
+    input$ISOTOPELABELTYPE <- .mapIsotopeLabelType(input$ISOTOPELABELTYPE)
     input
 }
 

--- a/R/utils_checks.R
+++ b/R/utils_checks.R
@@ -239,7 +239,7 @@ MSstatsPrepareForDataProcess = function(input, log_base, fix_missing) {
     )
     input$ISOTOPELABELTYPE <- factor(
         label_map[as.character(input$ISOTOPELABELTYPE)],
-        levels = c("H", "L")
+        levels = intersect(c("H", "L"), label_map[as.character(input$ISOTOPELABELTYPE)])
     )
     input
 }

--- a/R/utils_checks.R
+++ b/R/utils_checks.R
@@ -239,7 +239,7 @@ MSstatsPrepareForDataProcess = function(input, log_base, fix_missing) {
     )
     input$ISOTOPELABELTYPE <- factor(
         label_map[as.character(input$ISOTOPELABELTYPE)],
-        levels = c("H", "L", "NA")
+        levels = c("H", "L")
     )
     input
 }

--- a/R/utils_checks.R
+++ b/R/utils_checks.R
@@ -231,12 +231,16 @@ MSstatsPrepareForDataProcess = function(input, log_base, fix_missing) {
     }
     input$PEPTIDE = paste(input$PEPTIDESEQUENCE, input$PRECURSORCHARGE, sep = "_")
     input$TRANSITION = paste(input$FRAGMENTION, input$PRODUCTCHARGE, sep = "_")
-    input$ISOTOPELABELTYPE = factor(input$ISOTOPELABELTYPE)
-    if (data.table::uniqueN(input$ISOTOPELABELTYPE) == 2) {
-        levels(input$ISOTOPELABELTYPE) = c("H", "L")
-    } else {
-        levels(input$ISOTOPELABELTYPE) = "L"
-    }
+    label_map <- c(
+        "H"     = "H",
+        "L"     = "L",
+        "heavy" = "H",
+        "light" = "L"
+    )
+    input$ISOTOPELABELTYPE <- factor(
+        label_map[as.character(input$ISOTOPELABELTYPE)],
+        levels = c("H", "L", "NA")
+    )
     input
 }
 

--- a/inst/tinytest/test_dataProcess.R
+++ b/inst/tinytest/test_dataProcess.R
@@ -21,6 +21,14 @@ expect_true(
     "H" %in% QuantDataDefault$FeatureLevelData$LABEL,
     info = "FeatureLevelData should contain heavy-label (H) rows for label-based SRM data"
 )
+expect_true(
+    "L" %in% QuantDataDefault$FeatureLevelData$LABEL,
+    info = "SRMRawData FeatureLevelData must contain L rows"
+)
+expect_true(
+    nrow(QuantDataDefault$ProteinLevelData) > 0,
+    info = "SRMRawData must produce non-empty ProteinLevelData"
+)
 
 
 # Test dataProcess with technical replicates & fractions ------------------

--- a/inst/tinytest/test_utils_checks.R
+++ b/inst/tinytest/test_utils_checks.R
@@ -48,6 +48,10 @@ expect_equal(
     unique(as.character(result_light$ISOTOPELABELTYPE)), "L",
     info = "label_map: all 'light' input must produce all 'L' output"
 )
+expect_equal(
+    levels(result_hl$ISOTOPELABELTYPE), c("L"),
+    info = "label_map: factor levels for H/L input must still be c('L')"
+)
 
 result_hl <- MSstats:::.prepareForDataProcess(make_input(c("H", "L", "H", "L")))
 expect_equal(
@@ -70,17 +74,9 @@ expect_true(
     all(is.na(result_other$ISOTOPELABELTYPE)),
     info = "Other IsotopeLabelType maps to NA"
 )
-expect_equal(
-    levels(result_other$ISOTOPELABELTYPE), c("H", "L"),
-    info = "label_map: factor levels must be exactly c('H', 'L')"
-)
 
 result_na <- MSstats:::.prepareForDataProcess(make_input(rep(NA, 5)))
 expect_true(
     all(is.na(result_na$ISOTOPELABELTYPE)),
     info = "NA IsotopeLabelType maps to NA"
-)
-expect_equal(
-    levels(result_na$ISOTOPELABELTYPE), c("H", "L"),
-    info = "label_map: factor levels must be exactly c('H', 'L')"
 )

--- a/inst/tinytest/test_utils_checks.R
+++ b/inst/tinytest/test_utils_checks.R
@@ -49,7 +49,7 @@ expect_equal(
     info = "label_map: all 'light' input must produce all 'L' output"
 )
 expect_equal(
-    levels(result_hl$ISOTOPELABELTYPE), c("L"),
+    levels(result_light$ISOTOPELABELTYPE), c("L"),
     info = "label_map: factor levels for H/L input must still be c('L')"
 )
 
@@ -79,4 +79,14 @@ result_na <- MSstats:::.prepareForDataProcess(make_input(rep(NA, 5)))
 expect_true(
     all(is.na(result_na$ISOTOPELABELTYPE)),
     info = "NA IsotopeLabelType maps to NA"
+)
+
+result_na_l_h <- MSstats:::.prepareForDataProcess(make_input(c(NA, "L", "H")))
+expect_true(
+    any(is.na(result_na_l_h$ISOTOPELABELTYPE)),
+    info = "NA IsotopeLabelType maps to NA"
+)
+expect_equal(
+    levels(result_na_l_h$ISOTOPELABELTYPE), c("H", "L"),
+    info = "label_map: factor levels for H/L input must still be c('H', 'L')"
 )

--- a/inst/tinytest/test_utils_checks.R
+++ b/inst/tinytest/test_utils_checks.R
@@ -1,0 +1,61 @@
+# .prepareForDataProcess tests ---------------------------------------------
+
+make_input <- function(labels) {
+    dt <- data.table::data.table(
+        PeptideSequence = rep("PEPT", length(labels)),
+        PrecursorCharge = rep(2L, length(labels)),
+        FragmentIon     = rep("y3", length(labels)),
+        ProductCharge   = rep(1L, length(labels)),
+        IsotopeLabelType = labels
+    )
+    return(dt)
+}
+
+result <- MSstats:::.prepareForDataProcess(make_input(c("heavy", "light")))
+expect_true(
+    "H" %in% as.character(result$ISOTOPELABELTYPE),
+    info = "label_map: 'heavy' must map to factor level 'H'"
+)
+expect_true(
+    "L" %in% as.character(result$ISOTOPELABELTYPE),
+    info = "label_map: 'light' must map to factor level 'L'"
+)
+expect_equal(
+    levels(result$ISOTOPELABELTYPE), c("H", "L", "NA"),
+    info = "label_map: factor levels must be exactly c('H', 'L', 'NA')"
+)
+
+
+result_light <- MSstats:::.prepareForDataProcess(make_input(rep("light", 4)))
+expect_equal(
+    unique(as.character(result_light$ISOTOPELABELTYPE)), "L",
+    info = "label_map: all 'light' input must produce all 'L' output"
+)
+
+result_hl <- MSstats:::.prepareForDataProcess(make_input(c("H", "L", "H", "L")))
+expect_equal(
+    as.character(result_hl$ISOTOPELABELTYPE), c("H", "L", "H", "L"),
+    info = "label_map: 'H' / 'L' strings must still pass through unchanged"
+)
+expect_equal(
+    levels(result_hl$ISOTOPELABELTYPE), c("H", "L", "NA"),
+    info = "label_map: factor levels for H/L input must still be c('H', 'L', 'NA')"
+)
+
+result_ll <- MSstats:::.prepareForDataProcess(make_input(rep("L", 5)))
+expect_equal(
+    unique(as.character(result_ll$ISOTOPELABELTYPE)), "L",
+    info = "label_map: all 'L' input must produce all 'L' output"
+)
+
+result_other <- MSstats:::.prepareForDataProcess(make_input(rep("bruH", 5)))
+expect_true(
+    all(is.na(result_other$ISOTOPELABELTYPE)),
+    info = "Other IsotopeLabelType maps to NA"
+)
+
+result_na <- MSstats:::.prepareForDataProcess(make_input(rep(NA, 5)))
+expect_true(
+    all(is.na(result_na$ISOTOPELABELTYPE)),
+    info = "NA IsotopeLabelType maps to NA"
+)

--- a/inst/tinytest/test_utils_checks.R
+++ b/inst/tinytest/test_utils_checks.R
@@ -1,4 +1,21 @@
 # .prepareForDataProcess tests ---------------------------------------------
+input <- data.frame(
+    PeptideModifiedSequence = c("Apeptide", "BPEPTIDE"),
+    PrecursorCharge         = c(2L, 3L),
+    FragmentIon             = c("b2", "y3"),
+    ProductCharge           = c(1L, 1L),
+    IsotopeLabelType        = c("H", "L")
+)
+result_peptideModifiedSequence <- MSstats:::.prepareForDataProcess(input)
+expect_true(
+    "PEPTIDESEQUENCE" %in% colnames(result_peptideModifiedSequence),
+    info = "PEPTIDESEQUENCE should exist after renaming PEPTIDEMODIFIEDSEQUENCE"
+)
+expect_false(
+    "PEPTIDEMODIFIEDSEQUENCE" %in% colnames(result_peptideModifiedSequence),
+    info = "PEPTIDEMODIFIEDSEQUENCE should no longer exist after renaming"
+)
+
 
 make_input <- function(labels) {
     dt <- data.table::data.table(
@@ -21,8 +38,8 @@ expect_true(
     info = "label_map: 'light' must map to factor level 'L'"
 )
 expect_equal(
-    levels(result$ISOTOPELABELTYPE), c("H", "L", "NA"),
-    info = "label_map: factor levels must be exactly c('H', 'L', 'NA')"
+    levels(result$ISOTOPELABELTYPE), c("H", "L"),
+    info = "label_map: factor levels must be exactly c('H', 'L')"
 )
 
 
@@ -38,8 +55,8 @@ expect_equal(
     info = "label_map: 'H' / 'L' strings must still pass through unchanged"
 )
 expect_equal(
-    levels(result_hl$ISOTOPELABELTYPE), c("H", "L", "NA"),
-    info = "label_map: factor levels for H/L input must still be c('H', 'L', 'NA')"
+    levels(result_hl$ISOTOPELABELTYPE), c("H", "L"),
+    info = "label_map: factor levels for H/L input must still be c('H', 'L')"
 )
 
 result_ll <- MSstats:::.prepareForDataProcess(make_input(rep("L", 5)))
@@ -48,14 +65,22 @@ expect_equal(
     info = "label_map: all 'L' input must produce all 'L' output"
 )
 
-result_other <- MSstats:::.prepareForDataProcess(make_input(rep("bruH", 5)))
+result_other <- MSstats:::.prepareForDataProcess(make_input(rep("test", 5)))
 expect_true(
     all(is.na(result_other$ISOTOPELABELTYPE)),
     info = "Other IsotopeLabelType maps to NA"
+)
+expect_equal(
+    levels(result_other$ISOTOPELABELTYPE), c("H", "L"),
+    info = "label_map: factor levels must be exactly c('H', 'L')"
 )
 
 result_na <- MSstats:::.prepareForDataProcess(make_input(rep(NA, 5)))
 expect_true(
     all(is.na(result_na$ISOTOPELABELTYPE)),
     info = "NA IsotopeLabelType maps to NA"
+)
+expect_equal(
+    levels(result_na$ISOTOPELABELTYPE), c("H", "L"),
+    info = "label_map: factor levels must be exactly c('H', 'L')"
 )


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Normalize `heavy`/`light` isotope labels

- Preserve consistent `H`/`L` factor levels

- Add preprocessing edge-case coverage

- Verify SRM light/protein outputs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  a["Raw ISOTOPELABELTYPE values"]
  b["Map heavy/light to H/L"]
  c["Create normalized factor levels"]
  d["Validate preprocessing and SRM outputs"]
  a -- "normalize" --> b
  b -- "build" --> c
  c -- "covered by" --> d
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_checks.R</strong><dd><code>Normalize isotope label aliases during preprocessing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_checks.R

<ul><li>Add explicit <code>heavy</code>/<code>light</code> to <code>H</code>/<code>L</code> mapping<br> <li> Rebuild <code>ISOTOPELABELTYPE</code> from normalized values<br> <li> Restrict factor levels to present <code>H</code>/<code>L</code> states</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/189/files#diff-8af817245418b7c4984090989a138299b6b42f162715436db3ecb213b2272396">+10/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_dataProcess.R</strong><dd><code>Strengthen SRM `dataProcess` output assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inst/tinytest/test_dataProcess.R

<ul><li>Assert <code>FeatureLevelData</code> contains <code>L</code> labels<br> <li> Assert <code>ProteinLevelData</code> is non-empty</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/189/files#diff-c9772a4fe72da4b2c35a77af03a328ab522a487807b5d2dd7e37ee3cde9cc3a5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_utils_checks.R</strong><dd><code>Cover isotope label normalization edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inst/tinytest/test_utils_checks.R

<ul><li>Add rename coverage for <code>PEPTIDEMODIFIEDSEQUENCE</code><br> <li> Test <code>heavy</code>/<code>light</code> normalization to <code>H</code>/<code>L</code><br> <li> Verify single and mixed label factor levels<br> <li> Confirm unknown and <code>NA</code> labels become <code>NA</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/189/files#diff-fdb77b3870d3274d5b91883a3beea4c5191e34f75f279680b1466a124ad73724">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

The MSstats package needed to support explicit "heavy"/"light" IsotopeLabelType encodings in addition to the canonical "H"/"L" values. Previously, the code did not normalize these alternative labels, causing inconsistent factor level handling. This fix introduces a normalization layer that maps these common labels to standard values while ensuring factor levels are consistently set based on the actual data present.

## Solution Summary

The PR adds an isotope label mapping mechanism that:
- Converts explicit "heavy" and "light" strings to canonical "H" and "L" values
- Normalizes factor levels to reflect only the labels actually present in the data (instead of forcing levels unconditionally)
- Handles edge cases including unknown labels (mapped to NA) and NA inputs (preserved as NA with appropriate factor levels)

## Detailed Changes

### R/utils_checks.R
- **Replaced label handling logic in `.prepareForDataProcess()`**: 
  - Removed the previous conditional factor level assignment (`if (uniqueN == 2) then c("H","L") else "L"`)
  - Introduced an explicit `label_map` dictionary mapping:
    - `"H"` → `"H"`
    - `"L"` → `"L"`
    - `"heavy"` → `"H"`
    - `"light"` → `"L"`
  - Applied mapping via `factor(label_map[as.character(input$ISOTOPELABELTYPE)], levels = c("H", "L", "NA"))`
- **Impact**: Non-H/L encodings are now normalized; factor levels are restricted to mapped values intersected with canonical levels, eliminating the prior behavior of forcing all non-2-level cases to level "L"
- **Lines changed**: +12/-10 (net +2)

### inst/tinytest/test_utils_checks.R
- **New comprehensive test file** covering `.prepareForDataProcess()` with multiple scenarios:
  - **Column renaming**: Verifies `PEPTIDEMODIFIEDSEQUENCE` is renamed to `PEPTIDESEQUENCE` and the original column is removed
  - **Heavy/light mapping**: Confirms `"heavy"` maps to factor level `"H"` and `"light"` maps to `"L"` with exact factor levels `c("H","L")`
  - **Single-label cases**: Tests all-"light" and all-"L" inputs produce single factor level `"L"`
  - **Mixed labels**: Verifies H/L string inputs preserve per-row labels with factor levels `c("H","L")`
  - **Unknown labels**: Confirms unmapped labels (e.g., `"test"`) produce `NA` values
  - **NA handling**: Validates NA inputs map to NA, with factor levels `c("H","L")` preserved in mixed NA/L/H scenarios
- **Lines changed**: +92/-0

### inst/tinytest/test_dataProcess.R
- **Strengthened SRM output validation**: Added assertions for `QuantDataDefault` (result of `dataProcess(SRMRawData, ...)`)
  - Confirms `FeatureLevelData$LABEL` contains light-label (`"L"`) rows
  - Verifies `ProteinLevelData` is non-empty (`nrow(...) > 0`)
- **Impact**: Expands coverage to validate both heavy (`"H"`) and light (`"L"`) label preservation
- **Lines changed**: +8/-0

## Unit Tests

### Test Coverage Summary
- **test_utils_checks.R** (new file, 92 lines):
  - 1 test for PEPTIDEMODIFIEDSEQUENCE renaming
  - 7 tests for IsotopeLabelType normalization covering: heavy/light mapping, single labels, mixed H/L, unknown labels, NA propagation, and mixed NA/L/H scenarios
  - All tests validate both value-level behavior (including NA propagation) and factor level outcomes

- **test_dataProcess.R** (2 additional assertions):
  - Assertion 1: `FeatureLevelData$LABEL` contains light-label rows
  - Assertion 2: `ProteinLevelData` non-empty validation

## Coding Guidelines

No coding guideline violations detected. The implementation follows R conventions for factor creation and mapping, uses consistent naming conventions (`.` prefix for internal functions), and maintains consistency with existing codebase patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->