### PR TITLE
feat: Introduce normalization with unlabeled peptides

### DIFF
--- a/R/dataProcess.R
+++ b/R/dataProcess.R
@@ -557,8 +557,9 @@ MSstatsSummarizeSingleTMP = function(single_protein, impute, censored_symbol,
         return(list(NULL, NULL))
     } else {
         single_protein = single_protein[!is.na(newABUNDANCE), ]
-        is_labeled = nlevels(single_protein$LABEL) > 1
-        result = .runTukey(single_protein, is_labeled, censored_symbol, 
+        is_labeled_reference = "ref" %in% colnames(single_protein) &&
+            any(single_protein$ref, na.rm = TRUE)
+        result = .runTukey(single_protein, is_labeled_reference, censored_symbol,
                            remove50missing)
     }
     list(result, survival)

--- a/R/dataProcess.R
+++ b/R/dataProcess.R
@@ -557,8 +557,8 @@ MSstatsSummarizeSingleTMP = function(single_protein, impute, censored_symbol,
         return(list(NULL, NULL))
     } else {
         single_protein = single_protein[!is.na(newABUNDANCE), ]
-        is_labeled_reference = "ref" %in% colnames(single_protein) &&
-            any(single_protein$ref, na.rm = TRUE)
+        is_labeled_reference = "is_labeled_ref" %in% colnames(single_protein) &&
+            any(single_protein$is_labeled_ref, na.rm = TRUE)
         result = .runTukey(single_protein, is_labeled_reference, censored_symbol,
                            remove50missing)
     }

--- a/R/utils_censored.R
+++ b/R/utils_censored.R
@@ -31,49 +31,47 @@ MSstatsHandleMissing = function(input, summary_method, impute,
     
     if (impute & !is.null(missing_symbol)) {
         input$censored = FALSE
+        use_for_analysis = if ("ref" %in% colnames(input)) !input$ref else rep(TRUE, nrow(input))
         ## if intensity = 1, but abundance > cutoff after normalization, it also should be censored.
         if (!is.null(censored_cutoff)) {
-            quantiles = input[!is.na(INTENSITY) & INTENSITY > 1 & LABEL == "L", 
-                              quantile(ABUNDANCE, 
-                                       prob = c(0.01, 0.25, 0.5, 0.75, 
-                                                censored_cutoff), 
+            quantiles = input[use_for_analysis & !is.na(INTENSITY) & INTENSITY > 1,
+                              quantile(ABUNDANCE,
+                                       prob = c(0.01, 0.25, 0.5, 0.75,
+                                                censored_cutoff),
                                        na.rm = TRUE)]
             iqr = quantiles[4] - quantiles[2]
             multiplier = (quantiles[5] - quantiles[4]) / iqr
-            cutoff_lower = (quantiles[2] - multiplier * iqr) 
-            input$censored = !is.na(input$INTENSITY) & 
-                input$LABEL == "L" &
+            cutoff_lower = (quantiles[2] - multiplier * iqr)
+            input$censored = use_for_analysis & !is.na(input$INTENSITY) &
                 input$ABUNDANCE < cutoff_lower
             if (cutoff_lower <= 0 & !is.null(missing_symbol) & missing_symbol == "0") {
-                zero_one_filter = !is.na(input$ABUNDANCE) & input$ABUNDANCE <= 0
+                zero_one_filter = use_for_analysis & !is.na(input$ABUNDANCE) & input$ABUNDANCE <= 0
                 input$censored = ifelse(zero_one_filter, TRUE, input$censored)
             }
             if (!is.null(missing_symbol) & missing_symbol == "NA") {
-                input$censored = ifelse(is.na(input$INTENSITY), TRUE, 
+                input$censored = ifelse(use_for_analysis & is.na(input$INTENSITY), TRUE,
                                         input$censored)
             }
-            
-            msg = paste('** Log2 intensities under cutoff =', 
-                        format(cutoff_lower, digits = 5), 
+
+            msg = paste('** Log2 intensities under cutoff =',
+                        format(cutoff_lower, digits = 5),
                         ' were considered as censored missing values.')
             msg_2 = paste("** Log2 intensities =", missing_symbol, "were considered as censored missing values.")
-            
+
             getOption("MSstatsMsg")("INFO", msg)
             getOption("MSstatsMsg")("INFO", msg_2)
-            
+
             getOption("MSstatsLog")("INFO", msg)
             getOption("MSstatsLog")("INFO", msg_2)
-            
+
         } else {
             if (missing_symbol == '0') {
-                input$censored = input$LABEL == "L" & 
-                    !is.na(input$INTENSITY) &
+                input$censored = use_for_analysis & !is.na(input$INTENSITY) &
                     (input$INTENSITY == 1 | input$ABUNDANCE <= 0)
             } else if (missing_symbol == 'NA') {
-                input$censored = input$LABEL == "L" & is.na(input$ABUNDANCE)
+                input$censored = use_for_analysis & is.na(input$ABUNDANCE)
             }
         }
-        input[, censored := ifelse(LABEL == "H", FALSE, censored)]
     } else {
         input$censored = FALSE
     }
@@ -128,16 +126,17 @@ MSstatsHandleMissing = function(input, summary_method, impute,
 #' @param censored_symbol `censoredInt` parameter to dataProcess
 #' @keywords internal
 .getNonMissingFilter = function(input, impute, censored_symbol) {
+    use_for_analysis = if ("ref" %in% colnames(input)) !input$ref else rep(TRUE, nrow(input))
     if (impute) {
         if (!is.null(censored_symbol)) {
             if (censored_symbol == "0") {
-                nonmissing_filter = input$LABEL == "L" & !is.na(input$newABUNDANCE) & input$newABUNDANCE != 0
+                nonmissing_filter = use_for_analysis & !is.na(input$newABUNDANCE) & input$newABUNDANCE != 0
             } else if (censored_symbol == "NA") {
-                nonmissing_filter = input$LABEL == "L" & !is.na(input$newABUNDANCE)
-            }  
-        } 
+                nonmissing_filter = use_for_analysis & !is.na(input$newABUNDANCE)
+            }
+        }
     } else {
-        nonmissing_filter = input$LABEL == "L" & !is.na(input$newABUNDANCE) & input$newABUNDANCE != 0
+        nonmissing_filter = use_for_analysis & !is.na(input$newABUNDANCE) & input$newABUNDANCE != 0
     }
     nonmissing_filter
 }

--- a/R/utils_censored.R
+++ b/R/utils_censored.R
@@ -31,7 +31,7 @@ MSstatsHandleMissing = function(input, summary_method, impute,
     
     if (impute & !is.null(missing_symbol)) {
         input$censored = FALSE
-        use_for_analysis = if ("ref" %in% colnames(input)) !input$ref else rep(TRUE, nrow(input))
+        use_for_analysis = if ("is_labeled_ref" %in% colnames(input)) !input$is_labeled_ref else rep(TRUE, nrow(input))
         ## if intensity = 1, but abundance > cutoff after normalization, it also should be censored.
         if (!is.null(censored_cutoff)) {
             quantiles = input[use_for_analysis & !is.na(INTENSITY) & INTENSITY > 1,
@@ -126,7 +126,7 @@ MSstatsHandleMissing = function(input, summary_method, impute,
 #' @param censored_symbol `censoredInt` parameter to dataProcess
 #' @keywords internal
 .getNonMissingFilter = function(input, impute, censored_symbol) {
-    use_for_analysis = if ("ref" %in% colnames(input)) !input$ref else rep(TRUE, nrow(input))
+    use_for_analysis = if ("is_labeled_ref" %in% colnames(input)) !input$is_labeled_ref else rep(TRUE, nrow(input))
     if (impute) {
         if (!is.null(censored_symbol)) {
             if (censored_symbol == "0") {

--- a/R/utils_normalize.R
+++ b/R/utils_normalize.R
@@ -28,8 +28,13 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
     normalization_method = toupper(normalization_method)
     if (normalization_method == "NONE" | normalization_method == "FALSE") {
         return(input)
-    } else if (normalization_method == "EQUALIZEMEDIANS") {
+    }
+
+    if (normalization_method == "EQUALIZEMEDIANS") {
         input = .normalizeMedian(input)
+        if ("H" %in% input$LABEL) {
+            input[, ref := LABEL == "H"]
+        }
     } else if (normalization_method == "QUANTILE") {
         input = .normalizeQuantile(input)
     } else if (normalization_method == "GLOBALSTANDARDS") {
@@ -191,15 +196,24 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
 #' @keywords internal
 .normalizeGlobalStandards = function(input, peptides_dict, standards) {
     PeptideSequence = PEPTIDE = PROTEIN = median_by_fraction = NULL
-    Standard = FRACTION = LABEL = ABUNDANCE = RUN = GROUP = NULL
+    Standard = FRACTION = LABEL = ABUNDANCE = RUN = mean_by_run = NULL
 
     input_with_peptides <- merge(input, peptides_dict, by = "PEPTIDE", all.x = TRUE)
+    if (length(standards) == 1 && standards == "unlabeled") {
+        standards = unique(input_with_peptides[is.na(input_with_peptides$LABEL), ]$PeptideSequence)
+        if (length(standards) == 0) {
+            msg = "nameStandards = 'unlabeled' but no unlabeled peptides found in data."
+            getOption("MSstatsLog")("ERROR", msg)
+            stop(msg)
+        }
+    }
     standards_data <- input_with_peptides[
-        (PeptideSequence %in% standards | PROTEIN %in% standards) & 
-            GROUP != "0" & 
+        (PeptideSequence %in% standards | PROTEIN %in% standards) &
             !is.na(ABUNDANCE)
     ]
-    missing_standards <- standards[!standards %in% c(standards_data$PeptideSequence, standards_data$PROTEIN)]
+    missing_standards <- standards[
+        !standards %in% c(standards_data$PeptideSequence, standards_data$PROTEIN)
+    ]
     if (length(missing_standards) > 0) {
         msg <- paste("Global standard peptides or proteins,",
                      paste(missing_standards, collapse = ", "),
@@ -210,12 +224,12 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
     standards_data[, standard := ifelse(!is.na(PeptideSequence) & PeptideSequence %in% standards,
                                         PeptideSequence,
                                         PROTEIN)]
-    means_by_standard <- standards_data[, 
+    means_by_standard <- standards_data[,
                                         list(mean_abundance = mean(ABUNDANCE, na.rm = TRUE)),
                                         by = .(RUN, standard)
     ]
-    means_by_standard <- dcast(means_by_standard, 
-                               RUN ~ standard, 
+    means_by_standard <- dcast(means_by_standard,
+                               RUN ~ standard,
                                value.var = "mean_abundance")
     means_by_standard = data.table::melt(means_by_standard, id.vars = "RUN",
                                          variable.name = "Standard", value.name = "ABUNDANCE")
@@ -227,16 +241,11 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
     means_by_standard[, ABUNDANCE := NULL]
     means_by_standard[, Standard := NULL]
     means_by_standard = unique(means_by_standard)
-    
+
     input = merge(input, means_by_standard, all.x = TRUE, by = c("RUN", "FRACTION"))
-    input[, ABUNDANCE := ifelse(LABEL == "L", ABUNDANCE - mean_by_run + median_by_fraction, ABUNDANCE)]
-    
-    if (data.table::uniqueN(input$FRACTION) == 1L) {
-        msg = "Normalization : normalization with global standards protein - okay"
-    } else {
-        msg = "Normalization : normalization with global standards protein - okay"
-    }
-    getOption("MSstatsLog")("INFO", msg)
+    input[, ABUNDANCE := ABUNDANCE - mean_by_run + median_by_fraction]
+
+    getOption("MSstatsLog")("INFO", "Normalization : normalization with global standards protein - okay")
     input[ , !(colnames(input) %in% c("mean_by_run", "median_by_fraction")), with = FALSE]
 }
 

--- a/R/utils_normalize.R
+++ b/R/utils_normalize.R
@@ -33,7 +33,7 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
     if (normalization_method == "EQUALIZEMEDIANS") {
         input = .normalizeMedian(input)
         if ("H" %in% input$LABEL) {
-            input[, ref := LABEL == "H"]
+            input[, is_labeled_ref := LABEL == "H"]
         }
     } else if (normalization_method == "QUANTILE") {
         input = .normalizeQuantile(input)

--- a/R/utils_summarization_prepare.R
+++ b/R/utils_summarization_prepare.R
@@ -31,7 +31,7 @@ MSstatsPrepareForSummarization = function(input, method, impute, censored_symbol
         input[, ANOMALYSCORES := NA]
     }
     
-    add_ref_covariate = "ref" %in% colnames(input) && any(input$ref, na.rm = TRUE)
+    add_ref_covariate = "is_labeled_ref" %in% colnames(input) && any(input$is_labeled_ref, na.rm = TRUE)
     if (add_ref_covariate) {
       input[, ref_covariate := factor(ifelse(LABEL == "L", RUN, 0))]
     }

--- a/R/utils_summarization_prepare.R
+++ b/R/utils_summarization_prepare.R
@@ -31,9 +31,9 @@ MSstatsPrepareForSummarization = function(input, method, impute, censored_symbol
         input[, ANOMALYSCORES := NA]
     }
     
-    label = data.table::uniqueN(input$LABEL) == 2
-    if (label) {
-        input[, ref_covariate := factor(ifelse(LABEL == "L", RUN, 0))]
+    add_ref_covariate = "ref" %in% colnames(input) && any(input$ref, na.rm = TRUE)
+    if (add_ref_covariate) {
+      input[, ref_covariate := factor(ifelse(LABEL == "L", RUN, 0))]
     }
     
     if (is.element("remove", colnames(input))) {

--- a/inst/tinytest/test_dataProcess.R
+++ b/inst/tinytest/test_dataProcess.R
@@ -251,7 +251,7 @@ single_protein_labeled <- data.table::data.table(
     LABEL         = c("H",   "L",   "H",   "L"),
     RUN           = c("R1",  "R1",  "R2",  "R2"),
     newABUNDANCE  = c(10.0,  14.0,  12.0,  16.0),
-    ref           = c(TRUE,  FALSE, TRUE,  FALSE),
+    is_labeled_ref = c(TRUE,  FALSE, TRUE,  FALSE),
     censored      = rep(FALSE, 4),
     n_obs         = rep(2L,  4),
     n_obs_run     = rep(1L,  4),
@@ -272,7 +272,7 @@ expect_equal(
     sort(as.numeric(protein_level_labeled$LogIntensities)),
     c(15, 15),
     info = paste(
-        "MSstatsSummarizeSingleTMP: 'ref' column present with TRUE values must set",
+        "MSstatsSummarizeSingleTMP: 'is_labeled_ref' column present with TRUE values must set",
         "is_labeled_reference=TRUE, causing .runTukey to call .adjustLRuns;",
         "both runs should converge to H-adjusted LogIntensities of 15,",
         "not the raw L values (14, 16) that the unlabeled path would return"

--- a/inst/tinytest/test_dataProcess.R
+++ b/inst/tinytest/test_dataProcess.R
@@ -239,3 +239,42 @@ for (i in 1:nrow(protein_runs_4_5)) {
                            "than to AFPLAEWQPSDVDQR", afpla_abundance,
                            "(dist =", round(dist_to_afpla, 4), ")"))
 }
+
+
+# MSstatsSummarizeSingleTMP tests ------------------------------------------
+
+MSstatsConvert::MSstatsLogsSettings(FALSE)
+
+single_protein_labeled <- data.table::data.table(
+    PROTEIN       = rep("P1", 4),
+    FEATURE       = rep("F1", 4),
+    LABEL         = c("H",   "L",   "H",   "L"),
+    RUN           = c("R1",  "R1",  "R2",  "R2"),
+    newABUNDANCE  = c(10.0,  14.0,  12.0,  16.0),
+    ref           = c(TRUE,  FALSE, TRUE,  FALSE),
+    censored      = rep(FALSE, 4),
+    n_obs         = rep(2L,  4),
+    n_obs_run     = rep(1L,  4),
+    prop_features = rep(1.0, 4)
+)
+
+result_labeled <- MSstatsSummarizeSingleTMP(
+    single_protein_labeled,
+    impute          = FALSE,
+    censored_symbol = NULL,
+    remove50missing = FALSE,
+    aft_iterations  = 90
+)
+
+protein_level_labeled <- result_labeled[[1]]
+
+expect_equal(
+    sort(as.numeric(protein_level_labeled$LogIntensities)),
+    c(15, 15),
+    info = paste(
+        "MSstatsSummarizeSingleTMP: 'ref' column present with TRUE values must set",
+        "is_labeled_reference=TRUE, causing .runTukey to call .adjustLRuns;",
+        "both runs should converge to H-adjusted LogIntensities of 15,",
+        "not the raw L values (14, 16) that the unlabeled path would return"
+    )
+)

--- a/inst/tinytest/test_utils_censored.R
+++ b/inst/tinytest/test_utils_censored.R
@@ -65,3 +65,47 @@ imputed_val_p2 <- dt_zero[
 ]
 expect_equal(imputed_val_p2, expected_val_p2)
 
+
+# Test MSstatsHandleMissing
+make_cens_input <- function() {
+  data.table::data.table(
+    PROTEIN   = rep("P1", 8),
+    FEATURE   = rep("F1", 8),
+    LABEL     = c("L","L","L","L","H","H","H","H"),
+    RUN       = rep(c("R1","R2","R3","R4"), 2),
+    GROUP     = rep(c("G1","G1","G2","G2"), 2),
+    FRACTION  = rep(1L, 8),
+    INTENSITY = c(1L, 1L, 100L, 200L,   # L: first two will be censored
+                  1L, 1L, 100L, 200L),  # H: same intensities but must NOT be censored
+    ABUNDANCE = c(0, 0, log2(100), log2(200),
+                  0, 0, log2(100), log2(200)),
+    ref       = c(FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE)
+  )
+}
+
+cens_in <- make_cens_input()
+out_cens <- MSstatsHandleMissing(
+  cens_in,
+  summary_method  = "TMP",
+  impute          = TRUE,
+  missing_symbol  = "0",
+  censored_cutoff = NULL
+)
+
+# H rows must never be flagged as censored regardless of intensity
+expect_false(
+  any(out_cens[LABEL == "H", censored]),
+  info = "H rows (ref=TRUE) must never be flagged censored (use_for_analysis=FALSE)"
+)
+
+# L rows with intensity==1 must be flagged censored
+expect_true(
+  any(out_cens[LABEL == "L" & INTENSITY == 1L, censored]),
+  info = "L rows with intensity=1 (use_for_analysis=TRUE) must be flagged censored"
+)
+
+# L rows with intensity>1 must NOT be flagged censored
+expect_false(
+  any(out_cens[LABEL == "L" & INTENSITY > 1L, censored]),
+  info = "L rows with high intensity must not be flagged censored"
+)

--- a/inst/tinytest/test_utils_censored.R
+++ b/inst/tinytest/test_utils_censored.R
@@ -109,3 +109,67 @@ expect_false(
   any(out_cens[LABEL == "L" & INTENSITY > 1L, censored]),
   info = "L rows with high intensity must not be flagged censored"
 )
+
+
+# Tests for .getNonMissingFilter -----------------------------------------------
+
+dt_nmf_no_ref <- data.table::data.table(
+    newABUNDANCE = c(1.5, 0.0, NA_real_, 2.0)
+)
+result_no_ref <- MSstats:::.getNonMissingFilter(dt_nmf_no_ref, impute = FALSE, censored_symbol = "0")
+expect_equal(
+    result_no_ref, c(TRUE, FALSE, FALSE, TRUE),
+    info = ".getNonMissingFilter: without 'ref' column all rows have use_for_analysis=TRUE; zero and NA excluded"
+)
+
+dt_nmf_with_ref <- data.table::data.table(
+    newABUNDANCE = c(1.5, 2.0, 3.0, 1.0),
+    ref          = c(TRUE, FALSE, FALSE, TRUE)
+)
+result_with_ref <- MSstats:::.getNonMissingFilter(dt_nmf_with_ref, impute = FALSE, censored_symbol = "0")
+expect_equal(
+    result_with_ref, c(FALSE, TRUE, TRUE, FALSE),
+    info = ".getNonMissingFilter: ref=TRUE rows must be excluded (use_for_analysis=FALSE) regardless of abundance"
+)
+
+dt_nmf_ref_valid <- data.table::data.table(
+    newABUNDANCE = c(5.0, 3.0),
+    ref          = c(TRUE, FALSE)
+)
+result_ref_valid <- MSstats:::.getNonMissingFilter(dt_nmf_ref_valid, impute = FALSE, censored_symbol = "0")
+expect_false(
+    result_ref_valid[1],
+    info = ".getNonMissingFilter: ref=TRUE row with valid abundance must still yield FALSE"
+)
+expect_true(
+    result_ref_valid[2],
+    info = ".getNonMissingFilter: ref=FALSE row with valid abundance must yield TRUE"
+)
+
+dt_nmf_impute_na <- data.table::data.table(
+    newABUNDANCE = c(1.5, 0.0, NA_real_, 2.0)
+)
+result_impute_na <- MSstats:::.getNonMissingFilter(dt_nmf_impute_na, impute = TRUE, censored_symbol = "NA")
+expect_equal(
+    result_impute_na, c(TRUE, TRUE, FALSE, TRUE),
+    info = ".getNonMissingFilter: impute=TRUE, censored_symbol='NA' treats zero as non-missing"
+)
+
+dt_nmf_impute_zero <- data.table::data.table(
+    newABUNDANCE = c(1.5, 0.0, NA_real_, 2.0)
+)
+result_impute_zero <- MSstats:::.getNonMissingFilter(dt_nmf_impute_zero, impute = TRUE, censored_symbol = "0")
+expect_equal(
+    result_impute_zero, c(TRUE, FALSE, FALSE, TRUE),
+    info = ".getNonMissingFilter: impute=TRUE, censored_symbol='0' treats zero as missing"
+)
+
+dt_nmf_ref_impute_na <- data.table::data.table(
+    newABUNDANCE = c(1.5, 2.0, 0.0, 3.0),
+    ref          = c(TRUE, FALSE, FALSE, TRUE)
+)
+result_ref_impute_na <- MSstats:::.getNonMissingFilter(dt_nmf_ref_impute_na, impute = TRUE, censored_symbol = "NA")
+expect_equal(
+    result_ref_impute_na, c(FALSE, TRUE, TRUE, FALSE),
+    info = ".getNonMissingFilter: ref=TRUE rows excluded even when impute=TRUE, censored_symbol='NA'"
+)

--- a/inst/tinytest/test_utils_censored.R
+++ b/inst/tinytest/test_utils_censored.R
@@ -79,7 +79,7 @@ make_cens_input <- function() {
                   1L, 1L, 100L, 200L),  # H: same intensities but must NOT be censored
     ABUNDANCE = c(0, 0, log2(100), log2(200),
                   0, 0, log2(100), log2(200)),
-    ref       = c(FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE)
+    is_labeled_ref = c(FALSE,FALSE,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE)
   )
 }
 
@@ -95,7 +95,7 @@ out_cens <- MSstatsHandleMissing(
 # H rows must never be flagged as censored regardless of intensity
 expect_false(
   any(out_cens[LABEL == "H", censored]),
-  info = "H rows (ref=TRUE) must never be flagged censored (use_for_analysis=FALSE)"
+  info = "H rows (is_labeled_ref=TRUE) must never be flagged censored (use_for_analysis=FALSE)"
 )
 
 # L rows with intensity==1 must be flagged censored
@@ -119,31 +119,31 @@ dt_nmf_no_ref <- data.table::data.table(
 result_no_ref <- MSstats:::.getNonMissingFilter(dt_nmf_no_ref, impute = FALSE, censored_symbol = "0")
 expect_equal(
     result_no_ref, c(TRUE, FALSE, FALSE, TRUE),
-    info = ".getNonMissingFilter: without 'ref' column all rows have use_for_analysis=TRUE; zero and NA excluded"
+    info = ".getNonMissingFilter: without 'is_labeled_ref' column all rows have use_for_analysis=TRUE; zero and NA excluded"
 )
 
 dt_nmf_with_ref <- data.table::data.table(
-    newABUNDANCE = c(1.5, 2.0, 3.0, 1.0),
-    ref          = c(TRUE, FALSE, FALSE, TRUE)
+    newABUNDANCE   = c(1.5, 2.0, 3.0, 1.0),
+    is_labeled_ref = c(TRUE, FALSE, FALSE, TRUE)
 )
 result_with_ref <- MSstats:::.getNonMissingFilter(dt_nmf_with_ref, impute = FALSE, censored_symbol = "0")
 expect_equal(
     result_with_ref, c(FALSE, TRUE, TRUE, FALSE),
-    info = ".getNonMissingFilter: ref=TRUE rows must be excluded (use_for_analysis=FALSE) regardless of abundance"
+    info = ".getNonMissingFilter: is_labeled_ref=TRUE rows must be excluded (use_for_analysis=FALSE) regardless of abundance"
 )
 
 dt_nmf_ref_valid <- data.table::data.table(
-    newABUNDANCE = c(5.0, 3.0),
-    ref          = c(TRUE, FALSE)
+    newABUNDANCE   = c(5.0, 3.0),
+    is_labeled_ref = c(TRUE, FALSE)
 )
 result_ref_valid <- MSstats:::.getNonMissingFilter(dt_nmf_ref_valid, impute = FALSE, censored_symbol = "0")
 expect_false(
     result_ref_valid[1],
-    info = ".getNonMissingFilter: ref=TRUE row with valid abundance must still yield FALSE"
+    info = ".getNonMissingFilter: is_labeled_ref=TRUE row with valid abundance must still yield FALSE"
 )
 expect_true(
     result_ref_valid[2],
-    info = ".getNonMissingFilter: ref=FALSE row with valid abundance must yield TRUE"
+    info = ".getNonMissingFilter: is_labeled_ref=FALSE row with valid abundance must yield TRUE"
 )
 
 dt_nmf_impute_na <- data.table::data.table(
@@ -165,11 +165,11 @@ expect_equal(
 )
 
 dt_nmf_ref_impute_na <- data.table::data.table(
-    newABUNDANCE = c(1.5, 2.0, 0.0, 3.0),
-    ref          = c(TRUE, FALSE, FALSE, TRUE)
+    newABUNDANCE   = c(1.5, 2.0, 0.0, 3.0),
+    is_labeled_ref = c(TRUE, FALSE, FALSE, TRUE)
 )
 result_ref_impute_na <- MSstats:::.getNonMissingFilter(dt_nmf_ref_impute_na, impute = TRUE, censored_symbol = "NA")
 expect_equal(
     result_ref_impute_na, c(FALSE, TRUE, TRUE, FALSE),
-    info = ".getNonMissingFilter: ref=TRUE rows excluded even when impute=TRUE, censored_symbol='NA'"
+    info = ".getNonMissingFilter: is_labeled_ref=TRUE rows excluded even when impute=TRUE, censored_symbol='NA'"
 )

--- a/inst/tinytest/test_utils_normalize.R
+++ b/inst/tinytest/test_utils_normalize.R
@@ -327,6 +327,7 @@ expect_false(
   "ref" %in% colnames(out_lf),
   info = "label-free EQUALIZEMEDIANS must not add a 'ref' column"
 )
+labeled_in$RUN = as.factor(labeled_in$RUN)
 out_quant <- MSstatsNormalize(data.table::copy(labeled_in), "QUANTILE")
 expect_false(
   "ref" %in% colnames(out_quant),

--- a/inst/tinytest/test_utils_normalize.R
+++ b/inst/tinytest/test_utils_normalize.R
@@ -391,31 +391,31 @@ labeled_in <- create_labeled_input()
 out_eq <- MSstatsNormalize(data.table::copy(labeled_in), "EQUALIZEMEDIANS")
 
 expect_true(
-  "ref" %in% colnames(out_eq),
-  info = "EQUALIZEMEDIANS on labeled data must add 'ref' boolean column"
+  "is_labeled_ref" %in% colnames(out_eq),
+  info = "EQUALIZEMEDIANS on labeled data must add 'is_labeled_ref' boolean column"
 )
 expect_true(
-  all(out_eq[LABEL == "H", ref]),
-  info = "'ref' must be TRUE for every H row"
+  all(out_eq[LABEL == "H", is_labeled_ref]),
+  info = "'is_labeled_ref' must be TRUE for every H row"
 )
 expect_false(
-  any(out_eq[LABEL == "L", ref]),
-  info = "'ref' must be FALSE for every L row"
+  any(out_eq[LABEL == "L", is_labeled_ref]),
+  info = "'is_labeled_ref' must be FALSE for every L row"
 )
 expect_true(
-  is.logical(out_eq$ref),
-  info = "'ref' column must be of logical type"
+  is.logical(out_eq$is_labeled_ref),
+  info = "'is_labeled_ref' column must be of logical type"
 )
 
 lf_input <- data.table::copy(labeled_in)[LABEL == "L"]
 out_lf <- MSstatsNormalize(lf_input, "EQUALIZEMEDIANS")
 expect_false(
-  "ref" %in% colnames(out_lf),
-  info = "label-free EQUALIZEMEDIANS must not add a 'ref' column"
+  "is_labeled_ref" %in% colnames(out_lf),
+  info = "label-free EQUALIZEMEDIANS must not add an 'is_labeled_ref' column"
 )
 labeled_in$RUN = as.factor(labeled_in$RUN)
 out_quant <- MSstatsNormalize(data.table::copy(labeled_in), "QUANTILE")
 expect_false(
-  "ref" %in% colnames(out_quant),
-  info = "QUANTILE normalization must not add a 'ref' column"
+  "is_labeled_ref" %in% colnames(out_quant),
+  info = "QUANTILE normalization must not add an 'is_labeled_ref' column"
 )

--- a/inst/tinytest/test_utils_normalize.R
+++ b/inst/tinytest/test_utils_normalize.R
@@ -27,7 +27,7 @@ create_test_input <- function(standard_intensities, peptide2_intensities, peptid
                         "AAAAAAAAAAAAAAGAGAGAK_2_NA_NA", 
                         "AAAAAAAAAAAAVSRD_3_NA_NA"), 
                       each = n_runs),
-        LABEL = rep("L", n_proteins * n_runs),
+        LABEL = rep(c("L", "L", NA), each = n_runs),
         GROUP_ORIGINAL = rep(rep(c("Control", "Treatment"), each = n_runs/2), n_proteins),
         SUBJECT_ORIGINAL = rep(paste0("Subject", rep(1:n_subjects, each = n_fractions)), 
                                n_proteins * 2),
@@ -106,9 +106,95 @@ test_alternating_intensities_within_fractions <- function() {
                 info = "No normalization should occur when standard averages are equal across fractions")
 }
 
+standard_intensities_equal    <- rep(262144, 48)  # flat across all runs
+peptide3_intensities_baseline <- rep(262144, 48)  # non-standard reference
+test_unlabeled_standard_detected <- function() {
+  peptide_dict <- create_peptide_dictionary()
+  input <- create_test_input(standard_intensities_equal,
+                             standard_intensities_equal,
+                             peptide3_intensities_baseline)
+  
+  output <- MSstats:::.normalizeGlobalStandards(input, peptide_dict, "unlabeled")
+  
+  # Uniform standard => median_by_fraction == mean_by_run for every run,
+  # so ABUNDANCE is unchanged for all peptides.
+  expect_equal(
+    output$ABUNDANCE, input$ABUNDANCE,
+    info = "unlabeled path: uniform standard intensities should produce no shift in ABUNDANCE"
+  )
+}
+
+test_labeled_peptides_excluded_from_unlabeled_pool <- function() {
+  peptide_dict <- create_peptide_dictionary()
+  
+  # AAAAAAAAAAAAVSRD (the unlabeled standard) doubles in intensity for
+  # Treatment runs — this is the signal that should shift other peptides.
+  unlabeled_standard_intensities <- c(rep(262144, 24), rep(524288, 24))
+  input <- create_test_input(standard_intensities_equal,
+                             standard_intensities_equal,
+                             unlabeled_standard_intensities)
+  
+  output <- MSstats:::.normalizeGlobalStandards(input, peptide_dict, "unlabeled")
+  
+  # AAAAAAAAAAAAAAGAGAGAK is labeled, so it must NOT contribute to the
+  # normalization reference; its post-normalization values must differ from
+  # its pre-normalization values (it gets corrected by the unlabeled standard).
+  labeled_pre  <- input[grepl("AAAAAAAAAAAAAAGAGAGAK", PEPTIDE)]$ABUNDANCE
+  labeled_post <- output[grepl("AAAAAAAAAAAAAAGAGAGAK", PEPTIDE)]$ABUNDANCE
+  expect_false(
+    isTRUE(all.equal(labeled_pre, labeled_post)),
+    info = "unlabeled path: labeled peptide AAAAAAAAAAAAAAGAGAGAK must be adjusted, not used as standard"
+  )
+}
+
+test_unlabeled_normalization_shift <- function() {
+  peptide_dict <- create_peptide_dictionary()
+  
+  unlabeled_standard_intensities <- c(rep(262144, 24), rep(524288, 24))
+  input <- create_test_input(standard_intensities_equal,
+                             standard_intensities_equal,
+                             unlabeled_standard_intensities)
+  
+  output <- MSstats:::.normalizeGlobalStandards(input, peptide_dict, "unlabeled")
+  
+  control_abundance <- output[RUN %in% 1:24 &
+                                grepl("AAAAAAAAAAAAAAGAGAGAK_3", PEPTIDE) &
+                                !is.na(ABUNDANCE)]$ABUNDANCE
+  treatment_abundance <- output[RUN %in% 25:48 &
+                                  grepl("AAAAAAAAAAAAAAGAGAGAK_3", PEPTIDE) &
+                                  !is.na(ABUNDANCE)]$ABUNDANCE
+  
+  expect_true(
+    all(abs(control_abundance - 18.5) < 1e-10),
+    info = "unlabeled path: control runs shifted up by +0.5 to reach fraction median"
+  )
+  expect_true(
+    all(abs(treatment_abundance - 17.5) < 1e-10),
+    info = "unlabeled path: treatment runs shifted down by -0.5 to reach fraction median"
+  )
+}
+
+test_unlabeled_error_when_none_found <- function() {
+  peptide_dict <- create_peptide_dictionary()  # reused: no NA LABEL rows
+  input <- create_test_input(standard_intensities_equal,
+                             standard_intensities_equal,
+                             peptide3_intensities_baseline)
+  input$LABEL = "L"
+  
+  expect_error(
+    MSstats:::.normalizeGlobalStandards(input, peptide_dict, "unlabeled"),
+    pattern = "no unlabeled peptides found",
+    info = "unlabeled path: must error when peptide dictionary contains no NA-LABEL rows"
+  )
+}
+
 # Run tests ---------------------------------------------------------------------
 test_different_group_intensities()
 test_alternating_intensities_within_fractions()
+test_unlabeled_standard_detected()
+test_labeled_peptides_excluded_from_unlabeled_pool()
+test_unlabeled_normalization_shift()
+test_unlabeled_error_when_none_found()
 
 
 # Tests for MSstatsNormalize ---------------------------------------------------

--- a/inst/tinytest/test_utils_normalize.R
+++ b/inst/tinytest/test_utils_normalize.R
@@ -300,3 +300,35 @@ expect_false("ABUNDANCE_RUN" %in% colnames(out_labeled),
              info = ".normalizeMedian (labeled): ABUNDANCE_RUN column should be removed")
 expect_false("ABUNDANCE_FRACTION" %in% colnames(out_labeled),
              info = ".normalizeMedian (labeled): ABUNDANCE_FRACTION column should be removed")
+
+labeled_in <- create_labeled_input()
+out_eq <- MSstatsNormalize(data.table::copy(labeled_in), "EQUALIZEMEDIANS")
+
+expect_true(
+  "ref" %in% colnames(out_eq),
+  info = "EQUALIZEMEDIANS on labeled data must add 'ref' boolean column"
+)
+expect_true(
+  all(out_eq[LABEL == "H", ref]),
+  info = "'ref' must be TRUE for every H row"
+)
+expect_false(
+  any(out_eq[LABEL == "L", ref]),
+  info = "'ref' must be FALSE for every L row"
+)
+expect_true(
+  is.logical(out_eq$ref),
+  info = "'ref' column must be of logical type"
+)
+
+lf_input <- data.table::copy(labeled_in)[LABEL == "L"]
+out_lf <- MSstatsNormalize(lf_input, "EQUALIZEMEDIANS")
+expect_false(
+  "ref" %in% colnames(out_lf),
+  info = "label-free EQUALIZEMEDIANS must not add a 'ref' column"
+)
+out_quant <- MSstatsNormalize(data.table::copy(labeled_in), "QUANTILE")
+expect_false(
+  "ref" %in% colnames(out_quant),
+  info = "QUANTILE normalization must not add a 'ref' column"
+)

--- a/inst/tinytest/test_utils_summarization_prepare.R
+++ b/inst/tinytest/test_utils_summarization_prepare.R
@@ -4,7 +4,8 @@ make_srm_prep_input <- function() {
         FEATURE   = rep(c("F1", "F2"), each = 4),
         RUN       = c("R1","R1","R2","R2","R1","R1","R2","R2"),
         LABEL     = c("H","L","H","L","H","L","H","L"),
-        ABUNDANCE = c(10, 14, 11, 15, 10.2, 14.2, 11.2, 15.2)
+        ABUNDANCE = c(10, 14, 11, 15, 10.2, 14.2, 11.2, 15.2),
+        ref = c(TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE)
     )
 }
 
@@ -70,3 +71,4 @@ expect_false(
     "ref_covariate" %in% colnames(prep_labelfree),
     info = "ref_covariate: must NOT be created for label-free (single LABEL) data"
 )
+

--- a/inst/tinytest/test_utils_summarization_prepare.R
+++ b/inst/tinytest/test_utils_summarization_prepare.R
@@ -5,7 +5,7 @@ make_srm_prep_input <- function() {
         RUN       = c("R1","R1","R2","R2","R1","R1","R2","R2"),
         LABEL     = c("H","L","H","L","H","L","H","L"),
         ABUNDANCE = c(10, 14, 11, 15, 10.2, 14.2, 11.2, 15.2),
-        ref = c(TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE)
+        is_labeled_ref = c(TRUE, FALSE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE)
     )
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation and Solution

This PR introduces explicit handling of unlabeled peptides in normalization workflows and replaces label-cardinality-based logic with an explicit boolean reference flag (`ref` / `is_labeled_reference`) derived during median (EQUALIZEMEDIANS) normalization. The `ref` flag is propagated through normalization, censoring, and summarization flows so that unlabeled standards and labeled reference rows can be treated consistently (e.g., excluded from endogenous summarization and censoring calculations). The change enables GLOBALSTANDARDS normalization using unlabeled peptides, makes censoring/summarization operate only on endogenous (non-reference) rows, and simplifies label-guarding by depending on `ref` presence/content rather than LABEL counting.

## Detailed Changes

- R/dataProcess.R
  - MSstatsSummarizeSingleTMP: determine labeled/reference presence by checking for a `ref` column with any non-missing TRUE values instead of using LABEL cardinality (nlevels > 1).
  - Pass renamed boolean (`is_labeled_reference`) into .runTukey() and remove prior is_labeled computation.
  - Lines changed: +3/-2.

- R/utils_normalize.R
  - MSstatsNormalize: run EQUALIZEMEDIANS via a standalone conditional after early returns; when heavy labels exist, set a logical `ref` column (TRUE for heavy-label rows).
  - .normalizeGlobalStandards:
    - Support standards = "unlabeled": expand to PeptideSequence values from rows whose merged LABEL is NA; if none found, stop with an error.
    - Remove GROUP != "0" constraint when selecting standards_data.
    - Use mean_by_run (temporary) and apply ABUNDANCE := ABUNDANCE - mean_by_run + median_by_fraction across all labels (previous label-conditional adjustment removed).
    - Simplify logging to a single INFO message.
  - Lines changed: +26/-17.

- R/utils_censored.R
  - MSstatsHandleMissing:
    - Introduce use_for_analysis boolean mask derived from ref when present (otherwise all rows).
    - Constrain quantile cutoff computation, censored assignment, cutoff_lower derivation, zero/<=0 handling (missing_symbol == "0"), and INTENSITY-missing handling (missing_symbol == "NA") to use use_for_analysis.
    - Remove LABEL == "L" gates from these branches and delete post-processing that forced censored = FALSE for LABEL == "H".
  - .getNonMissingFilter: remove LABEL == "L" requirement; depend on use_for_analysis and non-NA newABUNDANCE (with optional non-zero constraint when censored_symbol == "0"); apply use_for_analysis in both impute and non-impute paths.
  - Lines changed: +23/-24.

- R/utils_summarization_prepare.R
  - MSstatsPrepareForSummarization: generate ref_covariate only if `ref` column exists and has at least one non-NA TRUE value (`"ref" %in% colnames(input) && any(input$ref, na.rm = TRUE)`); when created, keep existing factor computation (ifelse(LABEL == "L", RUN, 0)).
  - Lines changed: +3/-3.

- R/utils_feature_selection.R
  - Minor whitespace/formatting cleanup; no functional changes.

- Robustness and small fixes
  - Add handling for NA/removal cases in getProcessed paths to avoid failures when ref-driven rows are omitted.

## Unit Tests Added or Modified

- inst/tinytest/test_pr3_ref_flag.R (new)
  - Regression/tinytests verifying:
    - `ref` creation during median normalization (EQUALIZEMEDIANS).
    - Label-free paths do not create `ref`.
    - Censoring skips rows with ref == TRUE (reference rows excluded from censoring decisions).
    - getProcessed NA/removal robustness behavior.

- inst/tinytest/test_utils_censored.R (extended)
  - New test section with helper make_cens_input() constructing paired LABEL=="L"/LABEL=="H" rows parameterized by INTENSITY, ABUNDANCE, and ref.
  - Asserts expected censored outcomes:
    - All LABEL=="H" rows have censored == FALSE.
    - LABEL=="L" rows with INTENSITY == 1 have censored == TRUE.
    - LABEL=="L" rows with INTENSITY > 1 have censored == FALSE.

- inst/tinytest/test_utils_normalize.R (extended)
  - Tests for .normalizeGlobalStandards(..., "unlabeled"):
    - Uniformly intense unlabeled standard leaves ABUNDANCE unchanged.
    - Labeled peptides are excluded from unlabeled reference (post-normalization labeled peptide ABUNDANCE differs).
    - Unlabeled standard detection shifts run-specific ABUNDANCE for non-standard peptides across runs.
    - Error raised when no unlabeled peptides are found ("no unlabeled peptides found").
  - Tests that EQUALIZEMEDIANS creates logical `ref` column for labeled data (TRUE for LABEL == "H", FALSE for LABEL == "L"); ensures `ref` not added for label-free input or for QUANTILE normalization.

- inst/tinytest/test_utils_summarization_prepare.R (modified input)
  - Labeled test input now includes `ref` column with alternating TRUE/FALSE to exercise ref_covariate creation; label-free test remains unchanged.

## Coding Guidelines (violations or noteworthy deviations)

- No explicit coding guideline violations are documented in the provided changes. Changes follow existing codebase patterns:
  - Added and exercised tests for new behavior.
  - Propagation of a new boolean column (`ref`) and corresponding gating replaces ad-hoc LABEL cardinality checks, improving clarity.
  - Error handling added for missing unlabeled standards.
  - Minor formatting cleanup was applied.

If desired, reviewers may call out style/consistency concerns (naming conventions for `ref` vs `is_labeled_reference`, or the placement of EQUALIZEMEDIANS as a standalone if) during code review, but no clear guideline breaches are present in the provided summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add `ref`-based reference channel detection

- Normalize unlabeled standards across all labels

- Restrict censoring and summarization by `ref`

- Add regression tests for `ref` behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  n1["EQUALIZEMEDIANS adds ref flag"]
  n2["GLOBALSTANDARDS supports unlabeled peptides"]
  n3["Censoring analyzes only non-reference rows"]
  n4["Summarization uses ref-aware covariates"]
  n5["Tinytests validate ref behavior"]
  n1 -- "enables" --> n3
  n1 -- "drives" --> n4
  n2 -- "extends normalization" --> n4
  n3 -- "verified by" --> n5
  n4 -- "verified by" --> n5
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataProcess.R</strong><dd><code>Use `ref` to drive Tukey flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/dataProcess.R

<ul><li>Detect reference-labeled data from <code>ref</code><br> <li> Pass <code>is_labeled_reference</code> into <code>.runTukey</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/192/files#diff-321480d21bdc578dd9994bb29f9dcff991db1d3a4ae029079fc567e5a2eaaabc">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils_normalize.R</strong><dd><code>Extend normalization with `ref` and unlabeled standards</code>&nbsp; &nbsp; </dd></summary>
<hr>

R/utils_normalize.R

<ul><li>Add <code>ref</code> after <code>EQUALIZEMEDIANS</code> for <code>H</code><br> <li> Support <code>standards = "unlabeled"</code> discovery<br> <li> Error when unlabeled standards are missing<br> <li> Normalize all labels with global standards</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/192/files#diff-9cc61a8f7b75f55120f52fe0c381ac0af539782f47b26fc4122627ae01aad08f">+26/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_censored.R</strong><dd><code>Make censoring respect reference flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_censored.R

<ul><li>Derive <code>use_for_analysis</code> from <code>ref</code><br> <li> Apply censoring only to non-reference rows<br> <li> Scope zero and <code>NA</code> censoring similarly<br> <li> Remove label-specific nonmissing filtering</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/192/files#diff-2f11ad35baa24a08af42eb8a89c0128ef915f74ed83b7d47d69967131ca70455">+22/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils_summarization_prepare.R</strong><dd><code>Prepare summarization using `ref` semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_summarization_prepare.R

<ul><li>Add <code>ref_covariate</code> only when <code>ref</code> exists<br> <li> Replace label-count checks with <code>ref</code> detection<br> <li> Make <code>getProcessed</code> robust to <code>NA</code> removes</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/192/files#diff-8c234b16d698743745da5b03a47b44f5a292481acb2380b78e0c0b1e6e9ed55b">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_feature_selection.R</strong><dd><code>Minor formatting cleanup in feature selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_feature_selection.R

<ul><li>Apply whitespace-only cleanup in feature averaging code<br> <li> Preserve existing feature selection behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/192/files#diff-e9054759565afb845c6ef9c7a30eabaee7ef0676fe2abc322c71e32eff4dff5c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_pr3_ref_flag.R</strong><dd><code>Add regression tests for `ref` handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inst/tinytest/test_pr3_ref_flag.R

<ul><li>Test <code>ref</code> creation during median normalization<br> <li> Verify label-free paths do not add <code>ref</code><br> <li> Ensure censoring skips <code>ref=TRUE</code> rows<br> <li> Cover <code>getProcessed</code> handling of <code>NA</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/192/files#diff-da9d928f358a6309e1917feb97073819a93b08e4e52f93a13c409d44961a3087">+152/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

