### PR TITLE
fix(profile-plots): Add summary abundance value to summary profile plot

### DIFF
--- a/R/dataProcessPlots.R
+++ b/R/dataProcessPlots.R
@@ -165,7 +165,7 @@ dataProcessPlots = function(
           if("summary_plot" %in% names(plots)) {
               for(i in seq_along(plots[["summary_plot"]])) {
                   plot_i <- plots[["summary_plot"]][[paste("plot",i)]]
-                  summ_plotly_plot <- .convertGgplot2Plotly(plot_i,tips=c("FEATURE","RUN","ABUNDANCE"))
+                  summ_plotly_plot <- .convertGgplot2Plotly(plot_i,tips=c("FEATURE","RUN","newABUNDANCE"))
                   summ_plotly_plot = .fixLegendPlotlyPlotsDataprocess(summ_plotly_plot)
                   summ_plotly_plot = .fixCensoredPointsLegendProfilePlotsPlotly(summ_plotly_plot)
                   if(toupper(featureName) == "NA") {


### PR DESCRIPTION

### **PR Type**
Bug fix


___

### **Description**
- Fix summary plot tooltip abundance field

- Use `newABUNDANCE` in Plotly conversion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Summary profile ggplot"] -->|"convert with tips"| B["Plotly summary plot"]
  B -->|"use `newABUNDANCE`"| C["Correct abundance shown in hover"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataProcessPlots.R</strong><dd><code>Fix summary plot hover abundance field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/dataProcessPlots.R

<ul><li>Update summary profile plot Plotly tooltip fields<br> <li> Replace <code>ABUNDANCE</code> with <code>newABUNDANCE</code><br> <li> Ensure hover text shows summary abundance values</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/195/files#diff-6c7d294cb029339cc59d5c8dcf58cb44fda17c5666b1173dc709533f139b3596">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

