### PR TITLE
fix(profile-plot): Fix summaries for profile plots for protein turnover

### DIFF
--- a/R/dataProcessPlots.R
+++ b/R/dataProcessPlots.R
@@ -291,14 +291,18 @@ dataProcessPlots = function(
       ifelse(is_labeled_ref, "Reference", "Endogenous"),
       levels = c("Reference", "Endogenous")
     )]
+    raw_label_map = c("H" = "Reference", "L" = "Endogenous")
   } else {
     label_levels = levels(factor(processed$LABEL))
     if (length(label_levels) == 2) {
       processed[, LABEL := factor(LABEL, labels = c("Heavy", "Light"))]
+      raw_label_map = c("H" = "Heavy", "L" = "Light")
     } else if ("L" %in% label_levels) {
       processed[, LABEL := factor(LABEL, labels = c("Endogenous"))]
+      raw_label_map = c("L" = "Endogenous")
     } else {
       processed[, LABEL := factor(LABEL, labels = c("Heavy"))]
+      raw_label_map = c("H" = "Heavy")
     }
   }
 
@@ -362,7 +366,6 @@ dataProcessPlots = function(
                                  RUN = unique(summarized$RUN))
     summarized = merge(summarized, protein_by_run, by = c("Protein", "RUN"),
                        all.x = TRUE, all.y = TRUE)
-    summary_label = if ("Light" %in% levels(processed$LABEL)) "Light" else "Endogenous"
     if(!isPlotly) {
         savePlot(address, "ProfilePlot_wSummarization", width, height)
     }
@@ -372,7 +375,7 @@ dataProcessPlots = function(
       if (all(is.na(single_protein$ABUNDANCE))) {
         next()
       }
-      
+
       pept_feat = unique(single_protein[, list(PEPTIDE, FEATURE)])
       counts = pept_feat[, list(N = .N), by = "PEPTIDE"]$N
       s = rep(seq_along(counts), times = counts)
@@ -380,13 +383,13 @@ dataProcessPlots = function(
       groupNametemp = data.frame(groupName,
                                  FEATURE = unique(single_protein$FEATURE)[1],
                                  analysis = "Run summary")
-      
+
       single_protein_summ = summarized[Protein == all_proteins[i], ]
       quant = single_protein_summ[
         Protein == all_proteins[i],
         list(PROTEIN = unique(Protein), PEPTIDE = "Run summary",
              TRANSITION = "Run summary", FEATURE = "Run summary",
-             LABEL = summary_label, RUN = RUN,
+             LABEL = raw_label_map[LABEL], RUN = RUN,
              ABUNDANCE = LogIntensities, FRACTION = 1, 
              UPPERBOUND = if("Variance" %in% names(.SD)) LogIntensities + 1.96 * sqrt(Variance) else NA_real_, # 95% confidence interval
              LOWERBOUND = if("Variance" %in% names(.SD)) LogIntensities - 1.96 * sqrt(Variance) else NA_real_


### PR DESCRIPTION
___

### **PR Type**
Bug fix


___

### **Description**
- Fix summary labels in profile plots

- Map raw labels by labeling mode

- Support turnover and heavy/light outputs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  p["Processed labels"] -- "derive" --> m["Raw label map"]
  s["Summarized run data"] -- "apply mapped LABEL" --> q["Correct profile plot summaries"]
  m -- "used by" --> q
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataProcessPlots.R</strong><dd><code>Correct summary label mapping in profile plots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/dataProcessPlots.R

<ul><li>Add <code>raw_label_map</code> for each label mode<br> <li> Map <code>H</code>/<code>L</code> to displayed summary labels<br> <li> Replace fixed summary label selection<br> <li> Fix run summaries for turnover plots</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/196/files#diff-6c7d294cb029339cc59d5c8dcf58cb44fda17c5666b1173dc709533f139b3596">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

