### PR TITLE
fix(profile-plot): Only add error bars to profile plots if bounds exist

### DIFF
--- a/R/utils_dataprocess_plots.R
+++ b/R/utils_dataprocess_plots.R
@@ -172,14 +172,14 @@
                        aes(x = .data$RUN, y = .data$newABUNDANCE, 
                                   color = .data$analysis, size = .data$analysis, 
                                   shape = .data$censored)) +
-            geom_errorbar(data = input[input$PEPTIDE == "Run summary"],
-                          aes(x = .data$RUN, 
-                              ymin = .data$LOWERBOUND, 
+            geom_errorbar(data = input[input$PEPTIDE == "Run summary" & !is.na(input$UPPERBOUND) & !is.na(input$LOWERBOUND)],
+                          aes(x = .data$RUN,
+                              ymin = .data$LOWERBOUND,
                               ymax = .data$UPPERBOUND,
                               color = .data$analysis),
                           width = 0.3,
                           linewidth = 0.5,
-                          linetype = "solid") + 
+                          linetype = "solid") +
             scale_shape_manual(values = c(16, 1), 
                                labels = c("Detected data",
                                           "Censored missing data"))


### PR DESCRIPTION

### **PR Type**
Bug fix


___

### **Description**
- Skip error bars without bounds

- Filter `Run summary` rows by bounds

- Prevent invalid profile plot rendering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  input["Profile plot input rows"]
  filter["Filter Run summary rows with non-NA bounds"]
  errorbars["Render error bars only when valid"]
  plot["Stable censored profile plot"]
  input -- "apply bounds check" --> filter
  filter -- "provides valid rows" --> errorbars
  errorbars -- "avoids missing-bound errors" --> plot
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_dataprocess_plots.R</strong><dd><code>Guard profile error bars against missing bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_dataprocess_plots.R

<ul><li>Restricts <code>geom_errorbar()</code> data to <code>Run summary</code> rows<br> <li> Excludes rows with <code>NA</code> in <code>UPPERBOUND</code> or <code>LOWERBOUND</code><br> <li> Prevents adding error bars when bounds are unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/197/files#diff-7fee3fb0c1730a3acb302bdff934fa02e0ba3779b22dd6355e8cd7547a81519d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

Error bars in run-summary profile plots were being rendered regardless of whether confidence bound values were actually available. This could cause rendering issues or misleading visualizations when the `UPPERBOUND` and `LOWERBOUND` columns contained missing values (`NA`). The fix ensures that error bars are only added to the plot when both upper and lower bounds are present, preventing display artifacts and maintaining visual integrity.

## Changes

- Modified the `geom_errorbar()` call in the `.makeSummaryProfilePlot()` function in `R/utils_dataprocess_plots.R`
- Enhanced the data filtering condition for the error bar layer from:
  - `input[input$PEPTIDE == "Run summary"]`
  - to: `input[input$PEPTIDE == "Run summary" & !is.na(input$UPPERBOUND) & !is.na(input$LOWERBOUND)]`
- This addition of two new filtering conditions (`!is.na(input$UPPERBOUND)` and `!is.na(input$LOWERBOUND)`) ensures error bars are only rendered when both bound values are defined
- All other aesthetic properties and styling of the error bar layer remain unchanged

## Coding Guidelines

No violations of coding guidelines were identified. The change follows the existing code style and conventions used throughout the codebase for conditional data filtering in ggplot2 layer definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->