### PR TITLE
fix(globalStandards): Use median instead of mean for global standards normalization

### DIFF
--- a/R/utils_normalize.R
+++ b/R/utils_normalize.R
@@ -199,7 +199,8 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
     Standard = FRACTION = LABEL = ABUNDANCE = RUN = median_by_run = NULL
 
     input_with_peptides <- merge(input, peptides_dict, by = "PEPTIDE", all.x = TRUE)
-    if (length(standards) == 1 && standards == "unlabeled") {
+    is_unlabeled <- length(standards) == 1 && standards == "unlabeled"
+    if (is_unlabeled) {
         standards = unique(input_with_peptides[is.na(input_with_peptides$LABEL), ]$PeptideSequence)
         if (length(standards) == 0) {
             msg = "nameStandards = 'unlabeled' but no unlabeled peptides found in data."
@@ -224,25 +225,33 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
     standards_data[, standard := ifelse(!is.na(PeptideSequence) & PeptideSequence %in% standards,
                                         PeptideSequence,
                                         PROTEIN)]
-    medians_by_standard <- standards_data[,
-                                          list(median_abundance = median(ABUNDANCE, na.rm = TRUE)),
-                                          by = .(RUN, standard)
-    ]
-    medians_by_standard <- dcast(medians_by_standard,
-                                 RUN ~ standard,
-                                 value.var = "median_abundance")
-    medians_by_standard = data.table::melt(medians_by_standard, id.vars = "RUN",
-                                           variable.name = "Standard", value.name = "ABUNDANCE")
-    medians_by_standard[, median_by_run := median(ABUNDANCE, na.rm = TRUE), by = "RUN"]
-    medians_by_standard = merge(medians_by_standard, unique(input[, list(RUN, FRACTION)]),
-                                by = "RUN")
-    medians_by_standard[, median_by_fraction := median(median_by_run, na.rm = TRUE),
-                        by = "FRACTION"]
-    medians_by_standard[, ABUNDANCE := NULL]
-    medians_by_standard[, Standard := NULL]
-    medians_by_standard = unique(medians_by_standard)
+    if (is_unlabeled) {
+        run_summaries <- standards_data[,
+                                        list(median_by_run = median(ABUNDANCE, na.rm = TRUE)),
+                                        by = "RUN"]
+        run_summaries <- merge(run_summaries, unique(input[, list(RUN, FRACTION)]), by = "RUN")
+        run_summaries[, median_by_fraction := median(median_by_run, na.rm = TRUE), by = "FRACTION"]
+    } else {
+        medians_by_standard <- standards_data[,
+                                              list(median_abundance = median(ABUNDANCE, na.rm = TRUE)),
+                                              by = .(RUN, standard)
+        ]
+        medians_by_standard <- dcast(medians_by_standard,
+                                     RUN ~ standard,
+                                     value.var = "median_abundance")
+        medians_by_standard <- data.table::melt(medians_by_standard, id.vars = "RUN",
+                                                variable.name = "Standard", value.name = "ABUNDANCE")
+        medians_by_standard[, median_by_run := median(ABUNDANCE, na.rm = TRUE), by = "RUN"]
+        medians_by_standard <- merge(medians_by_standard, unique(input[, list(RUN, FRACTION)]),
+                                     by = "RUN")
+        medians_by_standard[, median_by_fraction := median(median_by_run, na.rm = TRUE),
+                            by = "FRACTION"]
+        medians_by_standard[, ABUNDANCE := NULL]
+        medians_by_standard[, Standard := NULL]
+        run_summaries <- unique(medians_by_standard)
+    }
 
-    input = merge(input, medians_by_standard, all.x = TRUE, by = c("RUN", "FRACTION"))
+    input = merge(input, run_summaries, all.x = TRUE, by = c("RUN", "FRACTION"))
     input[, ABUNDANCE := ABUNDANCE - median_by_run + median_by_fraction]
 
     getOption("MSstatsLog")("INFO", "Normalization : normalization with global standards protein - okay")

--- a/R/utils_normalize.R
+++ b/R/utils_normalize.R
@@ -196,7 +196,7 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
 #' @keywords internal
 .normalizeGlobalStandards = function(input, peptides_dict, standards) {
     PeptideSequence = PEPTIDE = PROTEIN = median_by_fraction = NULL
-    Standard = FRACTION = LABEL = ABUNDANCE = RUN = mean_by_run = NULL
+    Standard = FRACTION = LABEL = ABUNDANCE = RUN = median_by_run = NULL
 
     input_with_peptides <- merge(input, peptides_dict, by = "PEPTIDE", all.x = TRUE)
     if (length(standards) == 1 && standards == "unlabeled") {
@@ -224,29 +224,29 @@ MSstatsNormalize = function(input, normalization_method, peptides_dict = NULL, s
     standards_data[, standard := ifelse(!is.na(PeptideSequence) & PeptideSequence %in% standards,
                                         PeptideSequence,
                                         PROTEIN)]
-    means_by_standard <- standards_data[,
-                                        list(mean_abundance = mean(ABUNDANCE, na.rm = TRUE)),
-                                        by = .(RUN, standard)
+    medians_by_standard <- standards_data[,
+                                          list(median_abundance = median(ABUNDANCE, na.rm = TRUE)),
+                                          by = .(RUN, standard)
     ]
-    means_by_standard <- dcast(means_by_standard,
-                               RUN ~ standard,
-                               value.var = "mean_abundance")
-    means_by_standard = data.table::melt(means_by_standard, id.vars = "RUN",
-                                         variable.name = "Standard", value.name = "ABUNDANCE")
-    means_by_standard[, mean_by_run := mean(ABUNDANCE, na.rm = TRUE), by = "RUN"]
-    means_by_standard = merge(means_by_standard, unique(input[, list(RUN, FRACTION)]),
-                              by = "RUN")
-    means_by_standard[, median_by_fraction := median(mean_by_run, na.rm = TRUE),
-                      by = "FRACTION"]
-    means_by_standard[, ABUNDANCE := NULL]
-    means_by_standard[, Standard := NULL]
-    means_by_standard = unique(means_by_standard)
+    medians_by_standard <- dcast(medians_by_standard,
+                                 RUN ~ standard,
+                                 value.var = "median_abundance")
+    medians_by_standard = data.table::melt(medians_by_standard, id.vars = "RUN",
+                                           variable.name = "Standard", value.name = "ABUNDANCE")
+    medians_by_standard[, median_by_run := median(ABUNDANCE, na.rm = TRUE), by = "RUN"]
+    medians_by_standard = merge(medians_by_standard, unique(input[, list(RUN, FRACTION)]),
+                                by = "RUN")
+    medians_by_standard[, median_by_fraction := median(median_by_run, na.rm = TRUE),
+                        by = "FRACTION"]
+    medians_by_standard[, ABUNDANCE := NULL]
+    medians_by_standard[, Standard := NULL]
+    medians_by_standard = unique(medians_by_standard)
 
-    input = merge(input, means_by_standard, all.x = TRUE, by = c("RUN", "FRACTION"))
-    input[, ABUNDANCE := ABUNDANCE - mean_by_run + median_by_fraction]
+    input = merge(input, medians_by_standard, all.x = TRUE, by = c("RUN", "FRACTION"))
+    input[, ABUNDANCE := ABUNDANCE - median_by_run + median_by_fraction]
 
     getOption("MSstatsLog")("INFO", "Normalization : normalization with global standards protein - okay")
-    input[ , !(colnames(input) %in% c("mean_by_run", "median_by_fraction")), with = FALSE]
+    input[ , !(colnames(input) %in% c("median_by_run", "median_by_fraction")), with = FALSE]
 }
 
 

--- a/inst/tinytest/test_utils_normalize.R
+++ b/inst/tinytest/test_utils_normalize.R
@@ -116,7 +116,7 @@ test_unlabeled_standard_detected <- function() {
   
   output <- MSstats:::.normalizeGlobalStandards(input, peptide_dict, "unlabeled")
   
-  # Uniform standard => median_by_fraction == mean_by_run for every run,
+  # Uniform standard => median_by_fraction == median_by_run for every run,
   # so ABUNDANCE is unchanged for all peptides.
   expect_equal(
     output$ABUNDANCE, input$ABUNDANCE,

--- a/inst/tinytest/test_utils_normalize.R
+++ b/inst/tinytest/test_utils_normalize.R
@@ -117,7 +117,7 @@ test_unlabeled_standard_detected <- function() {
   output <- MSstats:::.normalizeGlobalStandards(input, peptide_dict, "unlabeled")
   
   # Uniform standard => median_by_fraction == median_by_run for every run,
-  # so ABUNDANCE is unchanged for all peptides.
+  # so ABUNDANCE is unchanged for all peptides (feature-level median, not per-peptide).
   expect_equal(
     output$ABUNDANCE, input$ABUNDANCE,
     info = "unlabeled path: uniform standard intensities should produce no shift in ABUNDANCE"


### PR DESCRIPTION

### **PR Type**
Bug fix


___

### **Description**
- Switch standard normalization from means to medians

- Derive run offsets from median standards

- Keep fraction equalization median-based

- Update test wording for median logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Global standards data"] -- "compute per-run per-standard medians" --> B["Standard median abundances"]
  B -- "collapse to run medians" --> C["median_by_run"]
  C -- "summarize by fraction" --> D["median_by_fraction"]
  D -- "adjust input `ABUNDANCE`" --> E["Median-normalized abundances"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_normalize.R</strong><dd><code>Replace mean-based normalization with medians</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_normalize.R

<ul><li>Replace mean-based standard aggregation with <code>median()</code><br> <li> Rename helper field from <code>mean_by_run</code> to <code>median_by_run</code><br> <li> Normalize <code>ABUNDANCE</code> using run and fraction medians<br> <li> Drop median helper columns after merging</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/198/files#diff-9cc61a8f7b75f55120f52fe0c381ac0af539782f47b26fc4122627ae01aad08f">+20/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_utils_normalize.R</strong><dd><code>Align test wording with median behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inst/tinytest/test_utils_normalize.R

<ul><li>Update test comment to reference <code>median_by_run</code><br> <li> Align unlabeled-standard explanation with median normalization</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/198/files#diff-1e2e0dcdf7bfa505e5177452356251c6b50ef76744cd6d191f1d995051d93ae5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

This PR switches the global standards normalization method from mean-based to median-based centering and scaling. The median is a more robust statistical measure that is less sensitive to outliers, making it better suited for handling real-world proteomics data where extreme values can skew mean-based calculations. This change aligns the global standards normalization approach with the existing median-based normalization method used elsewhere in MSstats.

## Changes

- **Modified `.normalizeGlobalStandards` function** (`R/utils_normalize.R`, lines 227-249):
  - Changed per-standard aggregation from `mean(ABUNDANCE, na.rm = TRUE)` to `median(ABUNDANCE, na.rm = TRUE)` when computing standard abundances by RUN
  - Updated per-RUN normalization factor from `mean_by_run` to `median_by_run` derived via `median(ABUNDANCE, na.rm = TRUE)` across standards
  - Maintained per-fraction normalization factor calculation as `median_by_fraction := median(median_by_run, na.rm = TRUE)` by FRACTION
  - Changed abundance adjustment formula from `ABUNDANCE - mean_by_run + median_by_fraction` to `ABUNDANCE - median_by_run + median_by_fraction`
  - Updated cleanup step to remove `median_by_run` and `median_by_fraction` columns (previously removed `mean_by_run` and `median_by_fraction`)

- **Updated test comment** (`inst/tinytest/test_utils_normalize.R`, line 119):
  - Modified test comment in `test_unlabeled_standard_detected` to reflect that when standards are uniform across runs and fractions, `median_by_fraction == median_by_run`, rather than the previous comparison involving `mean_by_run`

## Unit Tests

The existing test `test_unlabeled_standard_detected` was preserved with its executable logic unchanged. The test continues to verify that uniform standard intensities produce no shift in ABUNDANCE values, which remains valid under the median-based approach since the mathematical relationship holds: when all standards have equal abundances, both `median_by_run` and `median_by_fraction` will be identical, resulting in zero adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->