### PR TITLE
fix(dataProcessPlots): Fix error bar caps / whiskers for profile plots for plotly visualization

### DIFF
--- a/R/dataProcessPlots.R
+++ b/R/dataProcessPlots.R
@@ -155,6 +155,7 @@ dataProcessPlots = function(
                   og_plotly_plot <- .convertGgplot2Plotly(plot_i,tips=c("FEATURE","RUN","newABUNDANCE"))
                   og_plotly_plot = .fixLegendPlotlyPlotsDataprocess(og_plotly_plot)
                   og_plotly_plot = .fixCensoredPointsLegendProfilePlotsPlotly(og_plotly_plot)
+                  og_plotly_plot = .fixErrorBarCapsPlotly(og_plotly_plot)
 
                   if(toupper(featureName) == "NA") {
                       og_plotly_plot = .retainCensoredDataPoints(og_plotly_plot)
@@ -168,6 +169,7 @@ dataProcessPlots = function(
                   summ_plotly_plot <- .convertGgplot2Plotly(plot_i,tips=c("FEATURE","RUN","newABUNDANCE"))
                   summ_plotly_plot = .fixLegendPlotlyPlotsDataprocess(summ_plotly_plot)
                   summ_plotly_plot = .fixCensoredPointsLegendProfilePlotsPlotly(summ_plotly_plot)
+                  summ_plotly_plot = .fixErrorBarCapsPlotly(summ_plotly_plot)
                   if(toupper(featureName) == "NA") {
                       summ_plotly_plot = .retainCensoredDataPoints(summ_plotly_plot)
                   }
@@ -692,6 +694,15 @@ dataProcessPlots = function(
     if (!is.na(first_true_index)) {
         plot$x$data[[first_true_index]]$name <- "Censored missing data"
         plot$x$data[[first_true_index]]$showlegend <- TRUE
+    }
+    plot
+}
+
+.fixErrorBarCapsPlotly = function(plot, cap_width = 8) {
+    for (i in seq_along(plot$x$data)) {
+        if (!is.null(plot$x$data[[i]]$error_y)) {
+            plot$x$data[[i]]$error_y$width <- cap_width
+        }
     }
     plot
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix Plotly error bar caps

- Apply cap widths to profile plots

- Update original and summary conversions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ggplot["GGPlot profile plots"]
  convert["Convert to Plotly"]
  legend["Legend and censored point fixes"]
  caps["Set error bar cap width"]
  output["Rendered Plotly profile plots"]

  ggplot -- "converted" --> convert
  convert -- "post-process" --> legend
  legend -- "apply" --> caps
  caps -- "improves" --> output
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dataProcessPlots.R</strong><dd><code>Add Plotly error bar cap correction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/dataProcessPlots.R

<ul><li>Add <code>.fixErrorBarCapsPlotly()</code> helper<br> <li> Set <code>error_y$width</code> for Plotly traces<br> <li> Apply fix to <code>original_plot</code> conversions<br> <li> Apply fix to <code>summary_plot</code> conversions</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/200/files#diff-6c7d294cb029339cc59d5c8dcf58cb44fda17c5666b1173dc709533f139b3596">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

Profile plots are used in MSstats to identify potential sources of variation for each protein in mass spectrometry data. When using Plotly as the visualization backend (instead of ggplot2/PDF), error bar caps and whiskers were not being rendered with the correct width, leading to inconsistent visual representation of confidence intervals and standard deviations. This fix ensures that error bar cap widths are set consistently across all Plotly-based profile plot renderings.

## Changes

- Added new internal helper function `.fixErrorBarCapsPlotly()` that post-processes Plotly plot objects to ensure error bar cap widths are configured correctly
  - The function accepts a plot object and an optional `cap_width` parameter (defaults to 8)
  - Iterates through all traces in the plot's data structure (`plot$x$data`)
  - For each trace containing vertical error bars (`error_y` object), sets the `error_y$width` property to the specified cap width
  - Returns the modified plot object
- Applied this post-processing helper to both original and summary profile plot renderings when converting from ggplot2 to Plotly (lines 158 and 172 of `R/dataProcessPlots.R`)
- The fix is integrated into the existing pipeline that already applies other Plotly-specific adjustments such as legend fixes and censored points handling
- No other plotting modes or non-Plotly code paths were modified

## Testing

No new unit tests were added or modified. The change applies only to internal post-processing functions and does not alter the external API or function signatures.

## Coding Guidelines

No coding guideline violations detected. The implementation follows the existing patterns established by similar post-processing helper functions in the codebase (e.g., `.fixLegendPlotlyPlotsDataprocess()`, `.fixCensoredPointsLegendProfilePlotsPlotly()`), maintains consistent naming conventions with the dot-prefix for internal utilities, and is properly integrated into the existing visualization pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->