### PR TITLE
fix(comparison-plots): Add standard error confidence intervals to label

### DIFF
--- a/R/groupComparisonPlots.R
+++ b/R/groupComparisonPlots.R
@@ -158,7 +158,7 @@ groupComparisonPlots = function(
         if(isPlotly) {
             for(i in seq_along(plots)) {
                 plot <- plots[[i]]
-                plotly_plot <- .convertGgplot2Plotly(plot,tips=c("logFC"))
+                plotly_plot <- .convertGgplot2Plotly(plot,tips=c("text"))
                 plotly_plots[[i]] = list(plotly_plot)
             }
             if(address != FALSE) {

--- a/R/utils_groupcomparison_plots.R
+++ b/R/utils_groupcomparison_plots.R
@@ -293,7 +293,8 @@ colMin <- function(data) sapply(data, min, na.rm = TRUE)
                       data = input,
                       width = 0.1,
                       colour = "red") +
-        geom_point(size = dot.size, 
+        geom_point(aes(text = paste0("logFC: ", round(.data$logFC, 4), " ± ", round(.data$ciw, 4))),
+                   size = dot.size,
                    colour = "darkred") +
         scale_x_discrete('Comparison') +
         geom_hline(yintercept = 0, 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix Plotly comparison plot tooltips

- Show `logFC ± ciw` in hover labels

- Wire comparison plots to use text aesthetic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  gg["Comparison ggplot points"] -- "add hover text" --> text["logFC ± ciw label"]
  text -- "used by" --> plotly["Plotly tooltip rendering"]
  plotly["Plotly conversion"] -- "switch tips to `text`" --> hover["Correct comparison hover labels"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>groupComparisonPlots.R</strong><dd><code>Use text-based tooltips in Plotly conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/groupComparisonPlots.R

<ul><li>Update Plotly conversion to use <code>text</code> tooltips<br> <li> Replace tooltip field from <code>logFC</code> to point hover text<br> <li> Ensure comparison plots expose formatted interval labels</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/201/files#diff-3da455d0cc08a77d4977df23205500d5b78875bc08cfa1212f8d4c4ce7ac912e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils_groupcomparison_plots.R</strong><dd><code>Add confidence interval text to plot points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_groupcomparison_plots.R

<ul><li>Add point <code>text</code> aesthetic for hover content<br> <li> Format labels as <code>logFC</code> plus-minus <code>ciw</code><br> <li> Keep displayed values rounded to four decimals</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/201/files#diff-0a95c081260d7149148facc7a2c19d5b8783c66a77b8212333936e9602a0dfab">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

