### PR TITLE
fix(comparisonPlot): Add 95% CI description in tooltip

### DIFF
--- a/R/groupComparisonPlots.R
+++ b/R/groupComparisonPlots.R
@@ -421,8 +421,8 @@ groupComparisonPlots = function(
         vjust = ifelse(text.angle != 0, 1, 0.5)
         
         plot = .makeComparison(single_protein, log_base_FC, dot.size, x.axis.size,
-                               y.axis.size, text.angle, hjust, vjust, y.limdown, 
-                               y.limup)
+                               y.axis.size, text.angle, hjust, vjust, y.limdown,
+                               y.limup, sig)
         print(plot)
         plots[[i]] = plot
     }

--- a/R/utils_groupcomparison_plots.R
+++ b/R/utils_groupcomparison_plots.R
@@ -282,18 +282,18 @@ colMin <- function(data) sapply(data, min, na.rm = TRUE)
 #' @inheritParams groupComparisonPlots
 #' @keywords internal
 .makeComparison = function(
-    input, log_base, dot.size, x.axis.size, y.axis.size, 
-    text.angle, hjust, vjust, y.limdown, y.limup
+    input, log_base, dot.size, x.axis.size, y.axis.size,
+    text.angle, hjust, vjust, y.limdown, y.limup, sig
 ) {
     logFC = ciw = NULL
-    
+    ci_label = paste0("(", (1 - sig) * 100, "% CI)")
     protein = unique(input$Protein)
     plot = ggplot(input, aes(x = .data$Label, y = .data$logFC)) +
         geom_errorbar(aes(ymax = .data$logFC + .data$ciw, ymin = .data$logFC - .data$ciw),
                       data = input,
                       width = 0.1,
                       colour = "red") +
-        geom_point(aes(text = paste0("logFC: ", round(.data$logFC, 4), " ± ", round(.data$ciw, 4))),
+        geom_point(aes(text = paste0("logFC: ", round(.data$logFC, 4), " ± ", round(.data$ciw, 4), " ", ci_label)),
                    size = dot.size,
                    colour = "darkred") +
         scale_x_discrete('Comparison') +

--- a/man/dot-makeComparison.Rd
+++ b/man/dot-makeComparison.Rd
@@ -14,7 +14,8 @@
   hjust,
   vjust,
   y.limdown,
-  y.limup
+  y.limup,
+  sig
 )
 }
 \arguments{
@@ -29,6 +30,8 @@
 \item{y.axis.size}{size of axes labels, e.g. name of targeted proteins in heatmap. Default is 10.}
 
 \item{text.angle}{angle of x-axis labels represented each comparison at the bottom of graph in comparison plot. Default is 0.}
+
+\item{sig}{FDR cutoff for the adjusted p-values in heatmap and volcano plot. level of significance for comparison plot. 100(1-sig)\% confidence interval will be drawn.  sig=0.05 is default.}
 }
 \description{
 Create comparison plot


### PR DESCRIPTION
### **PR Type**
Bug fix, Documentation


___

### **Description**
- Pass `sig` into comparison plot helper

- Show CI percent in tooltips

- Document `sig`-driven CI behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["groupComparisonPlots"] 
  B["makeComparison helper"]
  C["Tooltip with CI percentage"]
  D["Rd documentation"]

  A -- "passes sig" --> B
  B -- "builds label" --> C
  D -- "documents sig argument" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>groupComparisonPlots.R</strong><dd><code>Forward significance level to plot helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/groupComparisonPlots.R

<ul><li>Pass <code>sig</code> into <code>.makeComparison</code><br> <li> Align helper inputs with CI calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/202/files#diff-3da455d0cc08a77d4977df23205500d5b78875bc08cfa1212f8d4c4ce7ac912e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils_groupcomparison_plots.R</strong><dd><code>Add dynamic confidence interval tooltip label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_groupcomparison_plots.R

<ul><li>Add <code>sig</code> parameter to <code>.makeComparison</code><br> <li> Derive confidence interval label from <code>sig</code><br> <li> Append CI percentage text to tooltip</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/202/files#diff-0a95c081260d7149148facc7a2c19d5b8783c66a77b8212333936e9602a0dfab">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dot-makeComparison.Rd</strong><dd><code>Document significance argument for comparison plots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

man/dot-makeComparison.Rd

<ul><li>Add <code>sig</code> to <code>.makeComparison</code> usage<br> <li> Document confidence interval meaning of <code>sig</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/202/files#diff-59b1e5bf474e90e20f7627bf2ad0ec48117fcbaa5476d827975525fd7e6ded66">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

This PR enhances the user interface of the comparison plot by providing clearer information about the confidence interval (CI) level displayed in interactive tooltips. When users hover over data points in a comparison plot, the tooltip now explicitly indicates what confidence level (e.g., 95% CI) is being visualized, removing ambiguity about the statistical measure being presented.

## Summary of Changes

- **Parameter Flow**: The `sig` parameter (FDR/significance cutoff) is now forwarded from the `groupComparisonPlots` function through to the internal `.makeComparison` helper function, enabling access to the significance level during plot construction.

- **Confidence Interval Label Generation**: The `.makeComparison` function now computes a formatted `ci_label` string as `"(X% CI)"` where X is calculated as `(1 - sig) × 100`. With the default `sig = 0.05`, this produces `"(95% CI)"`.

- **Tooltip Enhancement**: The point tooltip text in the comparison plot (via `geom_point` aesthetic) is updated to append the confidence interval label after the existing log fold change and confidence interval width values, resulting in tooltips like: `"logFC: 1.2345 ± 0.6789 (95% CI)"`.

- **Documentation Update**: The `.makeComparison` function's Roxygen documentation is updated to document the new `sig` parameter, clarifying that it sets the significance level for computing and displaying the `100(1-sig)%` confidence interval in the comparison plot.

## Files Modified

- `R/groupComparisonPlots.R`: Passes `sig` parameter to `.makeComparison` invocation (lines 423-425)
- `R/utils_groupcomparison_plots.R`: Adds `sig` parameter to function signature and implements `ci_label` creation and tooltip integration (lines 284-296)
- `man/dot-makeComparison.Rd`: Documents the new `sig` parameter and its role in confidence interval calculation

## Unit Tests

No unit tests are included in this PR to verify the tooltip text generation or the confidence interval label formatting. Existing test suites (test_groupComparison.R, test_groupComparisonQCPlots.R) do not contain tests that would validate this tooltip enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->