### PR TITLE
docs(impute): Update documentation w.r.t. censoredInt and MBimpute

### DIFF
--- a/R/dataProcess.R
+++ b/R/dataProcess.R
@@ -50,7 +50,8 @@
 #' censored, and imputation is disabled (MBimpute is ignored).
 #' @param MBimpute only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'.
 #' TRUE (default) imputes censored missing values using an Accelerated Failure
-#' Time model. FALSE leaves censored values at their cutoff without imputation.
+#' Time model. FALSE excludes censored observations from summarization entirely,
+#' treating them as missing at random; no imputed values are introduced.
 #' Has no effect when censoredInt = NULL, since no values are considered censored.
 #' See MSstats vignettes for recommendations on which imputation option to use.
 #' @param remove50missing only for summaryMethod = "TMP". TRUE removes the proteins 
@@ -198,7 +199,8 @@ dataProcess = function(
 #' where every run has at least 50\% missing values for each peptide. FALSE is default.
 #' @param impute only for summaryMethod = "TMP" and censored_symbol = 'NA' or '0'.
 #' TRUE (default) imputes censored missing values using an Accelerated Failure
-#' Time model. FALSE leaves censored values at their cutoff without imputation.
+#' Time model. FALSE excludes censored observations from summarization entirely,
+#' treating them as missing at random; no imputed values are introduced.
 #' Has no effect when censored_symbol = NULL, since no values are considered censored.
 #' @param numberOfCores Number of cores for parallel processing. When > 1, 
 #' a logfile named `MSstats_dataProcess_log_progress.log` is created to 

--- a/R/dataProcess.R
+++ b/R/dataProcess.R
@@ -41,16 +41,17 @@
 #' variance among intensities from features. FALSE means that we cannot assume equal 
 #' variance among intensities from features, then we will account for heterogeneous 
 #' variation from different features.
-#' @param censoredInt Missing values are censored or at random. 
-#' 'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-#' '0' uses zero intensities as censored intensity. 
-#' In this case, NA intensities are missing at random. 
-#' The output from Skyline should use '0'. 
-#' Null assumes that all NA intensites are randomly missing.
-#' @param MBimpute only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
-#' TRUE (default) imputes missing values with 'NA' or '0' (depending on censoredInt option) 
-#' by Accelerated failure model. If set to FALSE, no missing values are imputed. 
-#' FALSE is appropriate only when missingness is assumed to be at random.
+#' @param censoredInt Indicates how censored missing values are encoded in the
+#' 'Intensity' column. 'NA' (default) treats all NA intensities as left-censored
+#' (i.e., below the limit of detection). '0' treats zero intensities as
+#' left-censored; in this case NA intensities are assumed to be missing at
+#' random and are not censored. Skyline output should use '0'. NULL assumes
+#' that all missing values are missing at random — no values are treated as
+#' censored, and imputation is disabled (MBimpute is ignored).
+#' @param MBimpute only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'.
+#' TRUE (default) imputes censored missing values using an Accelerated Failure
+#' Time model. FALSE leaves censored values at their cutoff without imputation.
+#' Has no effect when censoredInt = NULL, since no values are considered censored.
 #' See MSstats vignettes for recommendations on which imputation option to use.
 #' @param remove50missing only for summaryMethod = "TMP". TRUE removes the proteins 
 #' where every run has at least 50\% missing values for each peptide. FALSE is default.
@@ -186,17 +187,19 @@ dataProcess = function(
 #' variance among intensities from features. FALSE means that we cannot assume 
 #' equal variance among intensities from features, then we will account for
 #' heterogeneous variation from different features.
-#' @param censored_symbol Missing values are censored or at random. 
-#' 'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-#' '0' uses zero intensities as censored intensity. 
-#' In this case, NA intensities are missing at random. 
-#' The output from Skyline should use '0'. 
-#' Null assumes that all NA intensites are randomly missing.
-#' @param remove50missing only for summaryMethod = "TMP". TRUE removes the proteins 
+#' @param censored_symbol Indicates how censored missing values are encoded in
+#' the 'Intensity' column. 'NA' (default) treats all NA intensities as
+#' left-censored (i.e., below the limit of detection). '0' treats zero
+#' intensities as left-censored; in this case NA intensities are assumed to be
+#' missing at random and are not censored. Skyline output should use '0'. NULL
+#' assumes that all missing values are missing at random — no values are treated
+#' as censored, and imputation is disabled (impute is ignored).
+#' @param remove50missing only for summaryMethod = "TMP". TRUE removes the proteins
 #' where every run has at least 50\% missing values for each peptide. FALSE is default.
-#' @param impute only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
-#' TRUE (default) imputes 'NA' or '0' (depending on censoredInt option) by Accelated failure model. 
-#' FALSE uses the values assigned by cutoffCensored
+#' @param impute only for summaryMethod = "TMP" and censored_symbol = 'NA' or '0'.
+#' TRUE (default) imputes censored missing values using an Accelerated Failure
+#' Time model. FALSE leaves censored values at their cutoff without imputation.
+#' Has no effect when censored_symbol = NULL, since no values are considered censored.
 #' @param numberOfCores Number of cores for parallel processing. When > 1, 
 #' a logfile named `MSstats_dataProcess_log_progress.log` is created to 
 #' track progress. Only works for Linux & Mac OS. Default is 1.

--- a/man/MSstatsSummarizeSingleTMP.Rd
+++ b/man/MSstatsSummarizeSingleTMP.Rd
@@ -15,18 +15,20 @@ MSstatsSummarizeSingleTMP(
 \arguments{
 \item{single_protein}{feature-level data for a single protein}
 
-\item{impute}{only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
-TRUE (default) imputes 'NA' or '0' (depending on censoredInt option) by Accelated failure model. 
-FALSE uses the values assigned by cutoffCensored}
+\item{impute}{only for summaryMethod = "TMP" and censored_symbol = 'NA' or '0'.
+TRUE (default) imputes censored missing values using an Accelerated Failure
+Time model. FALSE leaves censored values at their cutoff without imputation.
+Has no effect when censored_symbol = NULL, since no values are considered censored.}
 
-\item{censored_symbol}{Missing values are censored or at random. 
-'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-'0' uses zero intensities as censored intensity. 
-In this case, NA intensities are missing at random. 
-The output from Skyline should use '0'. 
-Null assumes that all NA intensites are randomly missing.}
+\item{censored_symbol}{Indicates how censored missing values are encoded in
+the 'Intensity' column. 'NA' (default) treats all NA intensities as
+left-censored (i.e., below the limit of detection). '0' treats zero
+intensities as left-censored; in this case NA intensities are assumed to be
+missing at random and are not censored. Skyline output should use '0'. NULL
+assumes that all missing values are missing at random — no values are treated
+as censored, and imputation is disabled (impute is ignored).}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins
 where every run has at least 50\% missing values for each peptide. FALSE is default.}
 
 \item{aft_iterations}{number of iterations for AFT model fitting}

--- a/man/MSstatsSummarizeSingleTMP.Rd
+++ b/man/MSstatsSummarizeSingleTMP.Rd
@@ -17,7 +17,8 @@ MSstatsSummarizeSingleTMP(
 
 \item{impute}{only for summaryMethod = "TMP" and censored_symbol = 'NA' or '0'.
 TRUE (default) imputes censored missing values using an Accelerated Failure
-Time model. FALSE leaves censored values at their cutoff without imputation.
+Time model. FALSE excludes censored observations from summarization entirely,
+treating them as missing at random; no imputed values are introduced.
 Has no effect when censored_symbol = NULL, since no values are considered censored.}
 
 \item{censored_symbol}{Indicates how censored missing values are encoded in

--- a/man/MSstatsSummarizeWithMultipleCores.Rd
+++ b/man/MSstatsSummarizeWithMultipleCores.Rd
@@ -20,18 +20,20 @@ MSstatsSummarizeWithMultipleCores(
 
 \item{method}{summarization method: "linear" or "TMP"}
 
-\item{impute}{only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
-TRUE (default) imputes 'NA' or '0' (depending on censoredInt option) by Accelated failure model. 
-FALSE uses the values assigned by cutoffCensored}
+\item{impute}{only for summaryMethod = "TMP" and censored_symbol = 'NA' or '0'.
+TRUE (default) imputes censored missing values using an Accelerated Failure
+Time model. FALSE leaves censored values at their cutoff without imputation.
+Has no effect when censored_symbol = NULL, since no values are considered censored.}
 
-\item{censored_symbol}{Missing values are censored or at random. 
-'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-'0' uses zero intensities as censored intensity. 
-In this case, NA intensities are missing at random. 
-The output from Skyline should use '0'. 
-Null assumes that all NA intensites are randomly missing.}
+\item{censored_symbol}{Indicates how censored missing values are encoded in
+the 'Intensity' column. 'NA' (default) treats all NA intensities as
+left-censored (i.e., below the limit of detection). '0' treats zero
+intensities as left-censored; in this case NA intensities are assumed to be
+missing at random and are not censored. Skyline output should use '0'. NULL
+assumes that all missing values are missing at random — no values are treated
+as censored, and imputation is disabled (impute is ignored).}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins
 where every run has at least 50\% missing values for each peptide. FALSE is default.}
 
 \item{equal_variance}{only for summaryMethod = "linear". Default is TRUE. 

--- a/man/MSstatsSummarizeWithMultipleCores.Rd
+++ b/man/MSstatsSummarizeWithMultipleCores.Rd
@@ -22,7 +22,8 @@ MSstatsSummarizeWithMultipleCores(
 
 \item{impute}{only for summaryMethod = "TMP" and censored_symbol = 'NA' or '0'.
 TRUE (default) imputes censored missing values using an Accelerated Failure
-Time model. FALSE leaves censored values at their cutoff without imputation.
+Time model. FALSE excludes censored observations from summarization entirely,
+treating them as missing at random; no imputed values are introduced.
 Has no effect when censored_symbol = NULL, since no values are considered censored.}
 
 \item{censored_symbol}{Indicates how censored missing values are encoded in

--- a/man/MSstatsSummarizeWithSingleCore.Rd
+++ b/man/MSstatsSummarizeWithSingleCore.Rd
@@ -19,18 +19,20 @@ MSstatsSummarizeWithSingleCore(
 
 \item{method}{summarization method: "linear" or "TMP"}
 
-\item{impute}{only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
-TRUE (default) imputes 'NA' or '0' (depending on censoredInt option) by Accelated failure model. 
-FALSE uses the values assigned by cutoffCensored}
+\item{impute}{only for summaryMethod = "TMP" and censored_symbol = 'NA' or '0'.
+TRUE (default) imputes censored missing values using an Accelerated Failure
+Time model. FALSE leaves censored values at their cutoff without imputation.
+Has no effect when censored_symbol = NULL, since no values are considered censored.}
 
-\item{censored_symbol}{Missing values are censored or at random. 
-'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-'0' uses zero intensities as censored intensity. 
-In this case, NA intensities are missing at random. 
-The output from Skyline should use '0'. 
-Null assumes that all NA intensites are randomly missing.}
+\item{censored_symbol}{Indicates how censored missing values are encoded in
+the 'Intensity' column. 'NA' (default) treats all NA intensities as
+left-censored (i.e., below the limit of detection). '0' treats zero
+intensities as left-censored; in this case NA intensities are assumed to be
+missing at random and are not censored. Skyline output should use '0'. NULL
+assumes that all missing values are missing at random — no values are treated
+as censored, and imputation is disabled (impute is ignored).}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins
 where every run has at least 50\% missing values for each peptide. FALSE is default.}
 
 \item{equal_variance}{only for summaryMethod = "linear". Default is TRUE. 

--- a/man/MSstatsSummarizeWithSingleCore.Rd
+++ b/man/MSstatsSummarizeWithSingleCore.Rd
@@ -21,7 +21,8 @@ MSstatsSummarizeWithSingleCore(
 
 \item{impute}{only for summaryMethod = "TMP" and censored_symbol = 'NA' or '0'.
 TRUE (default) imputes censored missing values using an Accelerated Failure
-Time model. FALSE leaves censored values at their cutoff without imputation.
+Time model. FALSE excludes censored observations from summarization entirely,
+treating them as missing at random; no imputed values are introduced.
 Has no effect when censored_symbol = NULL, since no values are considered censored.}
 
 \item{censored_symbol}{Indicates how censored missing values are encoded in

--- a/man/dataProcess.Rd
+++ b/man/dataProcess.Rd
@@ -80,17 +80,18 @@ variance among intensities from features. FALSE means that we cannot assume equa
 variance among intensities from features, then we will account for heterogeneous 
 variation from different features.}
 
-\item{censoredInt}{Missing values are censored or at random. 
-'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-'0' uses zero intensities as censored intensity. 
-In this case, NA intensities are missing at random. 
-The output from Skyline should use '0'. 
-Null assumes that all NA intensites are randomly missing.}
+\item{censoredInt}{Indicates how censored missing values are encoded in the
+'Intensity' column. 'NA' (default) treats all NA intensities as left-censored
+(i.e., below the limit of detection). '0' treats zero intensities as
+left-censored; in this case NA intensities are assumed to be missing at
+random and are not censored. Skyline output should use '0'. NULL assumes
+that all missing values are missing at random — no values are treated as
+censored, and imputation is disabled (MBimpute is ignored).}
 
-\item{MBimpute}{only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'. 
-TRUE (default) imputes missing values with 'NA' or '0' (depending on censoredInt option) 
-by Accelerated failure model. If set to FALSE, no missing values are imputed. 
-FALSE is appropriate only when missingness is assumed to be at random.
+\item{MBimpute}{only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'.
+TRUE (default) imputes censored missing values using an Accelerated Failure
+Time model. FALSE leaves censored values at their cutoff without imputation.
+Has no effect when censoredInt = NULL, since no values are considered censored.
 See MSstats vignettes for recommendations on which imputation option to use.}
 
 \item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 

--- a/man/dataProcess.Rd
+++ b/man/dataProcess.Rd
@@ -90,7 +90,8 @@ censored, and imputation is disabled (MBimpute is ignored).}
 
 \item{MBimpute}{only for summaryMethod = "TMP" and censoredInt = 'NA' or '0'.
 TRUE (default) imputes censored missing values using an Accelerated Failure
-Time model. FALSE leaves censored values at their cutoff without imputation.
+Time model. FALSE excludes censored observations from summarization entirely,
+treating them as missing at random; no imputed values are introduced.
 Has no effect when censoredInt = NULL, since no values are considered censored.
 See MSstats vignettes for recommendations on which imputation option to use.}
 

--- a/man/dot-getNonMissingFilterStats.Rd
+++ b/man/dot-getNonMissingFilterStats.Rd
@@ -9,12 +9,13 @@
 \arguments{
 \item{input}{data.table with data for a single protein}
 
-\item{censored_symbol}{Missing values are censored or at random. 
-'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-'0' uses zero intensities as censored intensity. 
-In this case, NA intensities are missing at random. 
-The output from Skyline should use '0'. 
-Null assumes that all NA intensites are randomly missing.}
+\item{censored_symbol}{Indicates how censored missing values are encoded in
+the 'Intensity' column. 'NA' (default) treats all NA intensities as
+left-censored (i.e., below the limit of detection). '0' treats zero
+intensities as left-censored; in this case NA intensities are assumed to be
+missing at random and are not censored. Skyline output should use '0'. NULL
+assumes that all missing values are missing at random — no values are treated
+as censored, and imputation is disabled (impute is ignored).}
 }
 \value{
 data.table

--- a/man/dot-runTukey.Rd
+++ b/man/dot-runTukey.Rd
@@ -15,14 +15,15 @@ subtracting the H value and adding back the H median, and only L results
 are returned. If FALSE (e.g. protein turnover), each label is summarized
 independently and results for all labels are returned.}
 
-\item{censored_symbol}{Missing values are censored or at random. 
-'NA' (default) assumes that all 'NA's in 'Intensity' column are censored. 
-'0' uses zero intensities as censored intensity. 
-In this case, NA intensities are missing at random. 
-The output from Skyline should use '0'. 
-Null assumes that all NA intensites are randomly missing.}
+\item{censored_symbol}{Indicates how censored missing values are encoded in
+the 'Intensity' column. 'NA' (default) treats all NA intensities as
+left-censored (i.e., below the limit of detection). '0' treats zero
+intensities as left-censored; in this case NA intensities are assumed to be
+missing at random and are not censored. Skyline output should use '0'. NULL
+assumes that all missing values are missing at random — no values are treated
+as censored, and imputation is disabled (impute is ignored).}
 
-\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins 
+\item{remove50missing}{only for summaryMethod = "TMP". TRUE removes the proteins
 where every run has at least 50\% missing values for each peptide. FALSE is default.}
 }
 \value{


### PR DESCRIPTION
# Motivation and Context

Based on this [google groups post](https://groups.google.com/g/msstats/c/JnNLD_2M5vk), it appears the MSstats documentation is not correct w.r.t. how the code handles censoredInt and MBimpute.  

___

### **PR Type**
Documentation


___

### **Description**
- Clarify censored missing-value semantics
  - Define `NA`, `0`, and `NULL`
  - Explain left-censoring and random missingness

- Document imputation behavior consistently
  - Describe AFT-based imputation wording
  - Note imputation ignored for `NULL`

- Regenerate matching `.Rd` references


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["R/dataProcess.R roxygen docs"]
  B["Clarified censoredInt and censored_symbol behavior"]
  C["Clarified MBimpute and impute behavior"]
  D["Regenerated .Rd documentation files"]
  A -- "updates" --> B
  A -- "updates" --> C
  B -- "propagates to" --> D
  C -- "propagates to" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>dataProcess.R</strong><dd><code>Clarify censored-value and imputation parameter docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/204/files#diff-321480d21bdc578dd9994bb29f9dcff991db1d3a4ae029079fc567e5a2eaaabc">+23/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MSstatsSummarizeSingleTMP.Rd</strong><dd><code>Sync TMP single-protein argument documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/204/files#diff-8411eae816a2e157b5456ce268e5d1fca97233810622154b9f4a0260d4c07bb4">+12/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MSstatsSummarizeWithMultipleCores.Rd</strong><dd><code>Update multicore summarization argument descriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/204/files#diff-ef37e2f50ab8b64c7199db2389ced120468149fd789785c715ff9df2ca750c02">+12/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MSstatsSummarizeWithSingleCore.Rd</strong><dd><code>Update single-core summarization argument descriptions</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/204/files#diff-d14089c6a1912fb273a991f61bcd86fc5ef2fe5667c527060ea55c777561227b">+12/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dataProcess.Rd</strong><dd><code>Refresh `dataProcess` censored and imputation docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/204/files#diff-1747362a46e443c4fb2e55547ec9d99da5f7108727ed6f9cc8173c502db37fdd">+12/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dot-getNonMissingFilterStats.Rd</strong><dd><code>Clarify internal censored-symbol parameter behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/204/files#diff-9a38be21b8e1c991eac68123e27f3da2b305c88ee88bdea045a7931593b8d004">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dot-runTukey.Rd</strong><dd><code>Align Tukey summarization censored-value documentation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/204/files#diff-aa1b28aad43de484953dd2db53e448d207d3168d89bf450b3addac13d9b35ed0">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

