### PR TITLE
fix(plotting): Fix groupComparisonPlots to render when viewport dims are low

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,5 @@
 ^docs$
 ^pkgdown$
 appspec.yml
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .idea
 *.Rproj
 
+.positai

--- a/R/groupComparisonPlots.R
+++ b/R/groupComparisonPlots.R
@@ -369,7 +369,7 @@ groupComparisonPlots = function(
         plot = .makeVolcano(single_label, label_name, log_base_FC, log_base_pval, x.lim, ProteinName, dot.size,
                             y.limdown, y.limup, text.size, FCcutoff, sig, x.axis.size, y.axis.size,
                             legend.size, log_adjp)
-        print(plot)
+        if (!isPlotly) print(plot)
         plots[[i]] = plot
     }
     if (address != FALSE) {
@@ -423,7 +423,7 @@ groupComparisonPlots = function(
         plot = .makeComparison(single_protein, log_base_FC, dot.size, x.axis.size,
                                y.axis.size, text.angle, hjust, vjust, y.limdown,
                                y.limup, sig)
-        print(plot)
+        if (!isPlotly) print(plot)
         plots[[i]] = plot
     }
     if (address != FALSE) {


### PR DESCRIPTION


### **PR Type**
Bug fix, Other


___

### **Description**
- Skip printing Plotly plot objects

- Prevent plot rendering viewport failures

- Keep generated plots stored normally

- Ignore local AI tool folders


___

### Diagram Walkthrough


```mermaid
flowchart LR
  gc["groupComparisonPlots loop"]
  make["Create plot object"]
  check["Check isPlotly"]
  print["Print non-Plotly plot"]
  store["Store plot in plots[[i]]"]
  gc -- "builds" --> make
  make -- "routes to" --> check
  check -- "`FALSE`" --> print
  check -- "`TRUE`" --> store
  print -- "then" --> store
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.Rbuildignore</strong><dd><code>Ignore local AI tooling directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.Rbuildignore

<ul><li>Add <code>.positai</code> to ignored build paths<br> <li> Add <code>.claude</code> to ignored build paths</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/206/files#diff-14fda507bd771db16c0fcb3a7d99002e54911cbe9f86bb2a6002562ee0fc0927">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>groupComparisonPlots.R</strong><dd><code>Guard Plotly plots from direct printing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/groupComparisonPlots.R

<ul><li>Only print plots when <code>isPlotly</code> is false<br> <li> Apply the guard in volcano plotting flow<br> <li> Apply the guard in comparison plotting flow<br> <li> Preserve plot assignment to <code>plots[[i]]</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/206/files#diff-3da455d0cc08a77d4977df23205500d5b78875bc08cfa1212f8d4c4ce7ac912e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

The `groupComparisonPlots` function has issues rendering plots when the viewport has low dimensions, particularly when used in the MSstatsShiny application with Plotly mode enabled. When `isPlotly = TRUE`, the function is intended to generate interactive Plotly visualizations for web-based rendering. However, unconditional printing of ggplot2 plot objects during Plotly rendering can interfere with the rendering pipeline and cause viewport-related failures. The fix conditionally suppresses these print statements when in Plotly mode, allowing the plots to render correctly regardless of viewport dimensions while maintaining full functionality by returning the plots in their respective lists.

## Changes

- **`.Rbuildignore`**: Updated to exclude hidden configuration directories `.positai` and `.claude` from R package builds, while continuing to exclude `appspec.yml`. Added trailing newline to file.

- **`.gitignore`**: Added `.positai` pattern to ignore list.

- **`R/groupComparisonPlots.R`**: 
  - Modified `.plotVolcano()` function to conditionally print volcano plots only when `!isPlotly` (i.e., when not in Plotly rendering mode)
  - Modified `.plotComparison()` function to conditionally print comparison plots only when `!isPlotly`
  - The plots themselves are still stored in the returned lists regardless of the `isPlotly` flag, preserving all functionality
  - Changes align with the existing pattern throughout the codebase where Plotly and ggplot2 rendering paths are differentiated by the `isPlotly` parameter

## Testing

No tests were added or modified to verify these changes. The existing test suite in `inst/tinytest/test_groupComparison.R` covers the `groupComparison` analysis function but does not include tests for the plotting functions or the `isPlotly` parameter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->