### PR TITLE
fix(anomaly-metrics): Fix plotting x-axis for anomaly metrics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,10 +54,10 @@ biocViews: ImmunoOncology, MassSpectrometry, Proteomics, Software, Normalization
 LazyData: true
 URL: http://msstats.org
 BugReports: https://groups.google.com/forum/#!forum/msstats
-RoxygenNote: 7.3.3
 Encoding: UTF-8
 NeedsCompilation: no
 Packaged: 2017-10-20 02:13:12 UTC; meenachoi
 LinkingTo: 
     Rcpp,
     RcppArmadillo
+Config/roxygen2/version: 8.0.0

--- a/R/plot_quality_metrics.R
+++ b/R/plot_quality_metrics.R
@@ -24,10 +24,12 @@
 #'   when \code{isPlotly = TRUE}.
 #'
 #' @details
-#' The x-axis order is determined by the factor levels of the \code{Run}
-#' column. When \code{runOrder} is passed to the converter the \code{Run}
-#' column is automatically set to an ordered factor; otherwise the runs appear
-#' in alphabetical order.
+#' The x-axis shows the integer order position of each run (1, 2, 3, ...)
+#' rather than the run name, to avoid clutter when run names are long.
+#' Positions are determined by the factor levels of the \code{Run} column.
+#' When \code{runOrder} is passed to the converter the \code{Run} column is
+#' automatically set to an ordered factor; otherwise the runs appear in
+#' alphabetical order.
 #'
 #' Metric values are averaged across fragment ions within each
 #' PeptideSequence + PrecursorCharge + Run combination before plotting, so
@@ -95,22 +97,25 @@ MSstatsQualityMetricsPlot <- function(input, metric = "AnomalyScores",
     )
     colnames(plot_df)[colnames(plot_df) == "x"] <- metric
 
-    # Preserve run factor ordering from the original data
-    plot_df$Run <- factor(plot_df$Run, levels = levels(input_df$Run))
+    # Preserve run factor ordering from the original data and map each
+    # Run to its integer position so the x-axis shows order numbers
+    # instead of run names (which can be long and clutter the axis).
+    run_levels <- levels(input_df$Run)
+    plot_df$RunOrder <- match(as.character(plot_df$Run), run_levels)
 
     p <- ggplot(plot_df,
-                aes(x     = .data[["Run"]],
+                aes(x     = .data[["RunOrder"]],
                     y     = .data[[metric]],
                     color = .data[["Precursor"]],
                     group = .data[["Precursor"]])) +
         geom_line(linewidth = 0.6) +
         geom_point(size = 1.5) +
-        scale_x_discrete(guide = guide_axis(angle = 45)) +
+        scale_x_continuous(breaks = seq(5, length(run_levels), by = 5)) +
         theme_bw() +
         theme(axis.text.x  = element_text(size = 8),
               legend.title = element_text(size = 9),
               legend.text  = element_text(size = 7)) +
-        labs(x        = "Run (temporal order)",
+        labs(x        = "Run order",
              y        = metric,
              title    = paste("Quality Metric:", metric),
              subtitle = which.Protein,

--- a/R/utils_documentation.R
+++ b/R/utils_documentation.R
@@ -1,8 +1,7 @@
 #' A dummy function to store shared documentation items.
 #' 
 #' @import data.table
-#' @importFrom MSstatsConvert MSstatsImport MSstatsClean MSstatsPreprocess 
-#' MSstatsBalancedDesign MSstatsMakeAnnotation MSstatsLogsSettings
+#' @importFrom MSstatsConvert MSstatsImport MSstatsClean MSstatsPreprocess MSstatsBalancedDesign MSstatsMakeAnnotation MSstatsLogsSettings
 #' 
 #' @param removeFewMeasurements TRUE (default) will remove the features that have 1 or 2 measurements across runs.
 #' @param useUniquePeptide TRUE (default) removes peptides that are assigned for more than one proteins. 

--- a/man/MSstatsQualityMetricsPlot.Rd
+++ b/man/MSstatsQualityMetricsPlot.Rd
@@ -43,10 +43,12 @@ coloured line, mirroring the feature-level view in
 \code{\link[MSstats]{dataProcessPlots}}.
 }
 \details{
-The x-axis order is determined by the factor levels of the \code{Run}
-column. When \code{runOrder} is passed to the converter the \code{Run}
-column is automatically set to an ordered factor; otherwise the runs appear
-in alphabetical order.
+The x-axis shows the integer order position of each run (1, 2, 3, ...)
+rather than the run name, to avoid clutter when run names are long.
+Positions are determined by the factor levels of the \code{Run} column.
+When \code{runOrder} is passed to the converter the \code{Run} column is
+automatically set to an ordered factor; otherwise the runs appear in
+alphabetical order.
 
 Metric values are averaged across fragment ions within each
 PeptideSequence + PrecursorCharge + Run combination before plotting, so

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -20,6 +20,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{MSstatsConvert}{\code{\link[MSstatsConvert]{DIANNtoMSstatsFormat}}, \code{\link[MSstatsConvert]{DIAUmpiretoMSstatsFormat}}, \code{\link[MSstatsConvert]{FragPipetoMSstatsFormat}}, \code{\link[MSstatsConvert]{MaxQtoMSstatsFormat}}, \code{\link[MSstatsConvert]{OpenMStoMSstatsFormat}}, \code{\link[MSstatsConvert]{OpenSWATHtoMSstatsFormat}}, \code{\link[MSstatsConvert]{PDtoMSstatsFormat}}, \code{\link[MSstatsConvert]{ProgenesistoMSstatsFormat}}, \code{\link[MSstatsConvert]{SkylinetoMSstatsFormat}}, \code{\link[MSstatsConvert]{SpectronauttoMSstatsFormat}}}
+  \item{MSstatsConvert}{\code{\link[MSstatsConvert:DIANNtoMSstatsFormat]{DIANNtoMSstatsFormat()}}, \code{\link[MSstatsConvert:DIAUmpiretoMSstatsFormat]{DIAUmpiretoMSstatsFormat()}}, \code{\link[MSstatsConvert:FragPipetoMSstatsFormat]{FragPipetoMSstatsFormat()}}, \code{\link[MSstatsConvert:MaxQtoMSstatsFormat]{MaxQtoMSstatsFormat()}}, \code{\link[MSstatsConvert:OpenMStoMSstatsFormat]{OpenMStoMSstatsFormat()}}, \code{\link[MSstatsConvert:OpenSWATHtoMSstatsFormat]{OpenSWATHtoMSstatsFormat()}}, \code{\link[MSstatsConvert:PDtoMSstatsFormat]{PDtoMSstatsFormat()}}, \code{\link[MSstatsConvert:ProgenesistoMSstatsFormat]{ProgenesistoMSstatsFormat()}}, \code{\link[MSstatsConvert:SkylinetoMSstatsFormat]{SkylinetoMSstatsFormat()}}, \code{\link[MSstatsConvert:SpectronauttoMSstatsFormat]{SpectronauttoMSstatsFormat()}}}
 }}
 


### PR DESCRIPTION

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Use numeric run-order x-axis

- Reduce clutter from long run names

- Refresh generated documentation metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Quality metrics data"]
  B["Run factor levels"]
  C["Numeric run positions"]
  D["Cleaner x-axis plot"]
  A -- "derive order from" --> B
  B -- "map runs to" --> C
  C -- "render as" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DESCRIPTION</strong><dd><code>Update roxygen configuration metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

DESCRIPTION

<ul><li>Adds <code>Config/roxygen2/version: 8.0.0</code>.<br> <li> Updates package documentation-generation metadata.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/209/files#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plot_quality_metrics.R</strong><dd><code>Plot metrics against numeric run order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/plot_quality_metrics.R

<ul><li>Documents numeric run-order positions on the x-axis.<br> <li> Maps <code>Run</code> factor levels to <code>RunOrder</code>.<br> <li> Uses continuous x-axis breaks every five runs.<br> <li> Renames x-axis label to <code>Run order</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/209/files#diff-1159e23368589720b64145554f30188e194df0c275cb1f3f01264617694f1825">+14/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_documentation.R</strong><dd><code>Refresh shared import documentation formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/utils_documentation.R

<ul><li>Consolidates <code>MSstatsConvert</code> import documentation onto one line.<br> <li> Keeps the same imported functions while refreshing roxygen formatting.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/209/files#diff-0f2eb1b89584322e5aa950cfb7e1524bad4c8fe4003e7374d407e9017bc53484">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MSstatsQualityMetricsPlot.Rd</strong><dd><code>Document numeric x-axis behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

man/MSstatsQualityMetricsPlot.Rd

<ul><li>Updates details for the numeric run-order x-axis.<br> <li> Explains run positions derive from <code>Run</code> factor levels.<br> <li> Clarifies behavior with and without <code>runOrder</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/209/files#diff-470be9fc2d39f2432ee94eda1c3caa1deeff2b9f8935277ee7fd4cc7fd1749dc">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reexports.Rd</strong><dd><code>Update generated reexport link syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

man/reexports.Rd

<ul><li>Updates <code>MSstatsConvert</code> reexport links to qualified Rd syntax.<br> <li> Adds function-style link labels with parentheses.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstats/pull/209/files#diff-ff04c900ffbdbf8cc2158721041e10a916b10dd2a30fbb952eff41cc3b5fd5ab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

