### PR TITLE
fix(qc-plots): Fix plot title for all proteins to generalize to metabolites

### DIFF
--- a/R/utils_dataprocess_plots.R
+++ b/R/utils_dataprocess_plots.R
@@ -237,7 +237,7 @@
     RUN = ABUNDANCE = Name = NULL
     
     if (all_proteins) {
-        plot_title = "All proteins"
+        plot_title = "All"
     } else {
         plot_title = unique(input$PROTEIN)
     }


### PR DESCRIPTION


## Motivation and context

QC plot titles must support both proteins and metabolites. The change removes protein-specific wording from the all-data QC plot title.

## Changes

- Changed the QC plot title from `"All proteins"` to `"All"` in `R/utils_dataprocess_plots.R`.
- No exported or public entities changed.

## Unit tests

- No unit tests were added or modified.

## Coding guidelines

- No coding guideline violations were identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->